### PR TITLE
Adjust rod's base export

### DIFF
--- a/cardillo/rods/_base_export.py
+++ b/cardillo/rods/_base_export.py
@@ -161,16 +161,6 @@ class RodExportBase(ABC):
                 target_points_2, n_segments, case=continuity
             )
 
-            # project directors on cubic C1 bezier curve
-            _, _, d1_segments = L2_projection_Bezier_curve(
-                d1s.T, n_segments, case=continuity
-            )
-            _, _, d2_segments = L2_projection_Bezier_curve(
-                d2s.T, n_segments, case=continuity
-            )
-            _, _, d3_segments = L2_projection_Bezier_curve(
-                d3s.T, n_segments, case=continuity
-            )
             if isinstance(self.cross_section, CircularCrossSection):
                 if circle_as_wedge:
 
@@ -354,29 +344,12 @@ class RodExportBase(ABC):
                 # create correct VTK ordering, see
                 # https://coreform.com/papers/implementation-of-rational-bezier-cells-into-VTK-report.pdf:
                 vtk_points_weights = []
-                vtk_d1_weights = []
-                vtk_d2_weights = []
-                vtk_d3_weights = []
                 for i in range(n_segments):
                     # compute all missing points of the layer
                     points_layer0 = compute_missing_points(i, 0)
                     points_layer1 = compute_missing_points(i, 1)
                     points_layer2 = compute_missing_points(i, 2)
                     points_layer3 = compute_missing_points(i, 3)
-
-                    # set all values the same per layer for directors
-                    d1_layer0 = np.repeat([d1_segments[i, 0]], 4, axis=0)
-                    d1_layer1 = np.repeat([d1_segments[i, 1]], 4, axis=0)
-                    d1_layer2 = np.repeat([d1_segments[i, 2]], 4, axis=0)
-                    d1_layer3 = np.repeat([d1_segments[i, 3]], 4, axis=0)
-                    d2_layer0 = np.repeat([d2_segments[i, 0]], 4, axis=0)
-                    d2_layer1 = np.repeat([d2_segments[i, 1]], 4, axis=0)
-                    d2_layer2 = np.repeat([d2_segments[i, 2]], 4, axis=0)
-                    d2_layer3 = np.repeat([d2_segments[i, 3]], 4, axis=0)
-                    d3_layer0 = np.repeat([d3_segments[i, 0]], 4, axis=0)
-                    d3_layer1 = np.repeat([d3_segments[i, 1]], 4, axis=0)
-                    d3_layer2 = np.repeat([d3_segments[i, 2]], 4, axis=0)
-                    d3_layer3 = np.repeat([d3_segments[i, 3]], 4, axis=0)
 
                     #######################
                     # 1. vertices (corners)
@@ -385,16 +358,10 @@ class RodExportBase(ABC):
                     # bottom
                     for j in range(4):
                         vtk_points_weights.append(points_layer0[j])
-                        vtk_d1_weights.append(d1_layer0[j])
-                        vtk_d2_weights.append(d2_layer0[j])
-                        vtk_d3_weights.append(d3_layer0[j])
 
                     # top
                     for j in range(4):
                         vtk_points_weights.append(points_layer3[j])
-                        vtk_d1_weights.append(d1_layer3[j])
-                        vtk_d2_weights.append(d2_layer3[j])
-                        vtk_d3_weights.append(d3_layer3[j])
 
                     ##########
                     # 2. edges
@@ -404,12 +371,6 @@ class RodExportBase(ABC):
                     for j in range(4):  # ordering for vtu file version>=2.0
                         vtk_points_weights.append(points_layer1[j])
                         vtk_points_weights.append(points_layer2[j])
-                        vtk_d1_weights.append(d1_layer1[j])
-                        vtk_d1_weights.append(d1_layer2[j])
-                        vtk_d2_weights.append(d2_layer1[j])
-                        vtk_d2_weights.append(d2_layer2[j])
-                        vtk_d3_weights.append(d3_layer1[j])
-                        vtk_d3_weights.append(d3_layer2[j])
 
             p_zeta = 3
             if isinstance(self.cross_section, CircularCrossSection):
@@ -459,9 +420,6 @@ class RodExportBase(ABC):
             if isinstance(self.cross_section, RectangularCrossSection):
                 point_data = {
                     "RationalWeights": vtk_points_weights[:, 3, None],
-                    "d1": vtk_d1_weights,
-                    "d2": vtk_d2_weights,
-                    "d3": vtk_d3_weights,
                 }
             else:
                 point_data = {

--- a/cardillo/rods/_base_export.py
+++ b/cardillo/rods/_base_export.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 import numpy as np
-from vtk import VTK_BEZIER_WEDGE, VTK_BEZIER_HEXAHEDRON
+from vtk import VTK_BEZIER_WEDGE, VTK_BEZIER_HEXAHEDRON, VTK_POLY_LINE
 
 from cardillo.utility.bezier import L2_projection_Bezier_curve
 
@@ -69,7 +69,7 @@ class RodExportBase(ABC):
 
             vtk_points = r_OPs.T
 
-            cells = [("line", [[i, i + 1] for i in range(num - 1)])]
+            cells = [(VTK_POLY_LINE, list(range(num)))]
 
             cell_data = {}
 


### PR DESCRIPTION
replace cell type "line" by VTK_POLY_LINE to fix  rod's centerline export and delete useless "L2_projection_Bezier_curve" for directors in rod's volume export for acceleration.