### PR TITLE
Speed up rod model

### DIFF
--- a/cardillo/rods/discretization/mesh1D.py
+++ b/cardillo/rods/discretization/mesh1D.py
@@ -31,7 +31,8 @@ class Mesh1D:
             )
 
         self.lagrangebasis = LagrangeBasis(self.degree)
-
+        self.value_basis = {}
+        
         # we might have different meshes for q and u, e.g. quaternions for
         # describing spatial rotations
         if dim_u is None:
@@ -163,16 +164,14 @@ class Mesh1D:
             return N
 
     def eval_basis(self, xi):
-        if not hasattr(self, "val_basis"):
-            self.val_basis = {}
-        if xi in self.val_basis.keys():
-            return self.val_basis[xi]
+        if xi in self.value_basis.keys():
+            return self.value_basis[xi]
         else:
             if self.basis == "Lagrange":
                 ret = self.lagrange_basis1D(xi, squeeze=True)
             elif self.basis == "Lagrange_Disc":
                 ret = self.lagrange_basis1D(xi, squeeze=False)
-            self.val_basis[xi] = ret
+            self.value_basis[xi] = ret
         return ret
 
     def quadrature_points(self):

--- a/cardillo/rods/discretization/mesh1D.py
+++ b/cardillo/rods/discretization/mesh1D.py
@@ -1,9 +1,5 @@
 import numpy as np
-from scipy.sparse.linalg import spsolve
-
-from cardillo.utility.coo_matrix import CooMatrix
-
-from .lagrange import lagrange_basis1D
+from .lagrange import LagrangeBasis
 from .gauss import gauss, lobatto
 
 
@@ -33,6 +29,8 @@ class Mesh1D:
             raise NotImplementedError(
                 f"Quadrature method '{quadrature}' is not implemented!"
             )
+
+        self.lagrangebasis = LagrangeBasis(self.degree)
 
         # we might have different meshes for q and u, e.g. quaternions for
         # describing spatial rotations
@@ -137,31 +135,45 @@ class Mesh1D:
 
     def basis1D(self, xis):
         if self.basis == "Lagrange":
-            return lagrange_basis1D(
-                self.degree,
+            return self.lagrange_basis1D(
                 xis,
-                self.derivative_order,
-                self.knot_vector,
                 squeeze=False,
             )
         elif self.basis == "Lagrange_Disc":
-            return lagrange_basis1D(
-                self.degree,
+            return self.lagrange_basis1D(
                 xis,
-                self.derivative_order,
-                self.knot_vector,
                 squeeze=False,
             )
 
+    def lagrange_basis1D(self, xis, squeeze=True):
+        xis = np.atleast_1d(xis)
+        nxis = len(xis)
+        N = np.zeros((self.derivative_order + 1, nxis, self.degree + 1))
+        for i, xi in enumerate(xis):
+            el = self.knot_vector.element_number(xi)[0]
+            interval = self.knot_vector.element_interval(el)
+            self.lagrangebasis.set_interval(interval)
+            N[0, i] = self.lagrangebasis(xi)
+            if self.derivative_order:
+                for j in range(1, self.derivative_order + 1):
+                    N[j, i] = self.lagrangebasis.deriv(xi, n=j)
+        if squeeze:
+            return N.squeeze()
+        else:
+            return N
+
     def eval_basis(self, xi):
-        if self.basis == "Lagrange":
-            return lagrange_basis1D(
-                self.degree, xi, self.derivative_order, self.knot_vector, squeeze=True
-            )
-        elif self.basis == "Lagrange_Disc":
-            return lagrange_basis1D(
-                self.degree, xi, self.derivative_order, self.knot_vector, squeeze=False
-            )
+        if not hasattr(self, "val_basis"):
+            self.val_basis = {}
+        if xi in self.val_basis.keys():
+            return self.val_basis[xi]
+        else:
+            if self.basis == "Lagrange":
+                ret = self.lagrange_basis1D(xi, squeeze=True)
+            elif self.basis == "Lagrange_Disc":
+                ret = self.lagrange_basis1D(xi, squeeze=False)
+            self.val_basis[xi] = ret
+        return ret
 
     def quadrature_points(self):
         self.qp = np.zeros((self.nelement, self.nquadrature))


### PR DESCRIPTION
I have increased the rod model's speed by 50% by calculating the lagrange bases only once. The problem is that each constraint in the position level will call the "eval_basis" function to get the position and orientation of the rod, so this function generates lagrange bases every time and consumes time.