### PR TITLE
Cardillo rod update

### DIFF
--- a/cardillo/rods/_base.py
+++ b/cardillo/rods/_base.py
@@ -1615,6 +1615,9 @@ def make_CosseratRodConstrained(mixed, constraints):
     else:
         CosseratRodBase = CosseratRodDisplacementBased
 
+    if len(idx_impressed) == 0:
+        CosseratRodBase = CosseratRod_PetrovGalerkin
+
     class CosseratRodConstrained(CosseratRodBase):
         def __init__(
             self,
@@ -1990,7 +1993,10 @@ def make_CosseratRodConstrained(mixed, constraints):
         ##############################
         def eval_stresses(self, t, q, la_c, la_g, xi, el=None):
             el = self.element_number(xi) if el is None else el
-            B_n, B_m = super().eval_stresses(t, q, la_c, la_g, xi, el)
+            if self.nconstraints == 6:
+                B_n, B_m = np.zeros(3, dtype=q.dtype), np.zeros(3, dtype=q.dtype)
+            else:
+                B_n, B_m = super().eval_stresses(t, q, la_c, la_g, xi, el)
 
             la_ge = la_g[self.elDOF_la_g[el]]
             # TODO: lets see how to avoid the flatten
@@ -2008,7 +2014,10 @@ def make_CosseratRodConstrained(mixed, constraints):
 
         def eval_strains(self, t, q, la_c, la_g, xi, el=None):
             el = self.element_number(xi) if el is None else el
-            eps_ga, eps_ka = super().eval_strains(t, q, la_c, la_g, xi, el)
+            if self.nconstraints == 6:
+                eps_ga, eps_ka = np.zeros(3, dtype=q.dtype), np.zeros(3, dtype=q.dtype)
+            else:
+                eps_ga, eps_ka = super().eval_strains(t, q, la_c, la_g, xi, el)
 
             eps_ga[self.constraints_gamma] = np.zeros(self.nconstraints_gamma)
             eps_ka[self.constraints_kappa] = np.zeros(self.nconstraints_kappa)

--- a/cardillo/rods/_base.py
+++ b/cardillo/rods/_base.py
@@ -33,6 +33,7 @@ class CosseratRod_PetrovGalerkin(RodExportBase, ABC):
         nquadrature_dyn=None,
         cross_section_inertias=CrossSectionInertias(),
         idx_impressed=None,
+        name=None,
     ):
         """Base class for Petrov-Galerkin Cosserat rod formulations with
         quaternions for the nodal orientation parametrization.
@@ -74,8 +75,17 @@ class CosseratRod_PetrovGalerkin(RodExportBase, ABC):
             Inertia properties of cross-sections: Cross-section mass density and
             Cross-section inertia tensor represented in the cross-section-fixed
             B-Basis.
-        idx_impressed:
-
+        idx_impressed : array_like
+            Set of numbers between 0 and 5 to indicate which stress
+            contributions obtain an independent field.
+            0 : n_1 axial force.
+            1 : n_2 shear force in e_y^B-direction.
+            2 : n_3 shear force in e_z^B-direction.
+            3 : m_1 torsion.
+            4 : m_2 bending moment around e_y^B-direction.
+            5 : m_3 bending moment around e_z^B-direction.
+        name : str
+            Name of contribution.
         """
         # call base class for all export properties
         super().__init__(cross_section)
@@ -84,6 +94,7 @@ class CosseratRod_PetrovGalerkin(RodExportBase, ABC):
         self.material_model = material_model
         self.cross_section_inertias = cross_section_inertias
         self.idx_impressed = np.arange(6) if idx_impressed is None else idx_impressed
+        self.name = "Cosserat_rod" if name is None else name
 
         # distinguish between inertia quadrature and other parts
         self.nquadrature = nquadrature
@@ -1117,6 +1128,7 @@ class CosseratRodMixed(CosseratRod_PetrovGalerkin):
         nquadrature_dyn=None,
         cross_section_inertias=CrossSectionInertias(),
         idx_impressed=None,
+        name=None,
     ):
         """Base class for mixed Petrov-Galerkin Cosserat rod formulations with
         quaternions for the nodal orientation parametrization.
@@ -1158,7 +1170,7 @@ class CosseratRodMixed(CosseratRod_PetrovGalerkin):
             Inertia properties of cross-sections: Cross-section mass density and
             Cross-section inertia tensor represented in the cross-section-fixed
             B-Basis.
-        idx_mixed : array_like
+        idx_impressed : array_like
             Set of numbers between 0 and 5 to indicate which stress
             contributions obtain an independent field.
             0 : n_1 axial force.
@@ -1167,7 +1179,8 @@ class CosseratRodMixed(CosseratRod_PetrovGalerkin):
             3 : m_1 torsion.
             4 : m_2 bending moment around e_y^B-direction.
             5 : m_3 bending moment around e_z^B-direction.
-
+        name : str
+            Name of contribution.
         """
 
         # call base class CosseratRod
@@ -1183,6 +1196,7 @@ class CosseratRodMixed(CosseratRod_PetrovGalerkin):
             nquadrature_dyn=nquadrature_dyn,
             cross_section_inertias=cross_section_inertias,
             idx_impressed=idx_impressed,
+            name=name,
         )
 
         #######################################################
@@ -1615,6 +1629,7 @@ def make_CosseratRodConstrained(mixed, constraints):
             u0=None,
             nquadrature_dyn=None,
             cross_section_inertias=CrossSectionInertias(),
+            name=None,
         ):
             """Base class for Petrov-Galerkin Cosserat rod formulations with
             additional constraints with quaternions for the nodal orientation
@@ -1657,6 +1672,8 @@ def make_CosseratRodConstrained(mixed, constraints):
                 Inertia properties of cross-sections: Cross-section mass density and
                 Cross-section inertia tensor represented in the cross-section-fixed
                 B-Basis.
+            name : str
+                Name of contribution.
             """
             super().__init__(
                 cross_section,
@@ -1670,6 +1687,7 @@ def make_CosseratRodConstrained(mixed, constraints):
                 nquadrature_dyn=nquadrature_dyn,
                 cross_section_inertias=cross_section_inertias,
                 idx_impressed=idx_impressed,
+                name=name,
             )
 
             ##################################################################

--- a/cardillo/rods/_base_export.py
+++ b/cardillo/rods/_base_export.py
@@ -1,19 +1,43 @@
 from abc import ABC, abstractmethod
 import numpy as np
-from vtk import VTK_BEZIER_WEDGE, VTK_BEZIER_HEXAHEDRON, VTK_POLY_LINE
+from vtk import (
+    VTK_LAGRANGE_CURVE,
+)
+from warnings import warn
 
 from cardillo.utility.bezier import L2_projection_Bezier_curve
+from cardillo.math import cross3, norm
 
 from ._cross_section import (
-    CrossSection,
+    ExportableCrossSection,
     CircularCrossSection,
     RectangularCrossSection,
+    vtk_bezier,
+    vtk_lagrange,
 )
+
+"""
+very usefull for the ordering: 
+https://coreform.com/papers/implementation-of-rational-bezier-cells-into-VTK-report.pdf
+"""
 
 
 class RodExportBase(ABC):
-    def __init__(self, cross_section: CrossSection):
+    def __init__(self, cross_section: ExportableCrossSection):
         self.cross_section = cross_section
+
+        self._export_dict = {
+            # "level": "centerline + directors",
+            "level": "volume",
+            "num_per_cell": "Auto",
+            "ncells": "Auto",
+            "stresses": False,
+            "volume_directors": False,
+            "surface_normals": False,
+            "hasCap": False,
+        }
+
+        self.preprocessed_export = False
 
     @abstractmethod
     def r_OP(self, t, q, xi, B_r_CP): ...
@@ -25,7 +49,6 @@ class RodExportBase(ABC):
         q_body = q[self.qDOF]
         r = []
         for xi in np.linspace(0, 1, num):
-            xi = (xi,)
             qp = q_body[self.local_qDOF_P(xi)]
             r.append(self.r_OP(1, qp, xi))
         return np.array(r).T
@@ -38,7 +61,6 @@ class RodExportBase(ABC):
         d3 = []
 
         for xi in np.linspace(0, 1, num=num):
-            xi = (xi,)
             qp = q_body[self.local_qDOF_P(xi)]
             r.append(self.r_OP(1, qp, xi))
 
@@ -49,388 +71,491 @@ class RodExportBase(ABC):
 
         return np.array(r).T, np.array(d1).T, np.array(d2).T, np.array(d3).T
 
-    def export(
-        self, sol_i, continuity="C1", circle_as_wedge=True, level="volume", **kwargs
-    ):
+    def surface(self, q, xi, eta, el):
+        q_body = q[self.qDOF]
+        qp = q_body[self.elDOF[el]]
+        N, N_xi = self.basis_functions_r(xi, el)
+        eval = self._eval(qp, xi, N, N_xi)
+        r_OP = eval[0]
+        A_IB = eval[1]
+        # B_gamma = eval[2]
+        # B_kappa_IB = eval[3]
+
+        B_r_PQ = self.cross_section.B_r_PQ(eta)
+
+        r_OQ = r_OP + A_IB @ B_r_PQ
+        return r_OQ
+
+    def surface_normal(self, q, xi, eta, el):
+        q_body = q[self.qDOF]
+        qp = q_body[self.elDOF[el]]
+        N, N_xi = self.basis_functions_r(xi, el)
+        eval = self._eval(qp, xi, N, N_xi)
+        # r_OP = eval[0]
+        A_IB = eval[1]
+        B_gamma = eval[2]
+        B_kappa_IB = eval[3]
+
+        B_r_PQ = self.cross_section.B_r_PQ(eta)
+        B_r_PQ_eta = self.cross_section.B_r_PQ_eta(eta)
+
+        # r_OQ = r_OP + A_IB @ B_r_PQ
+        r_OQ_xi = A_IB @ B_gamma + A_IB @ cross3(B_kappa_IB, B_r_PQ)
+        r_OQ_eta = A_IB @ B_r_PQ_eta
+
+        n = cross3(r_OQ_eta, r_OQ_xi)
+        return n / norm(n)
+
+    def preprocess_export(self):
+        ########################
+        # evaluate export dict #
+        ########################
+        # number if cells to be exported
+        if self._export_dict["ncells"] == "Auto":
+            self._export_dict["ncells"] = self.nelement
+
+        assert isinstance(self._export_dict["ncells"], int)
+        assert self._export_dict["ncells"] >= 1
+        ncells = self._export_dict["ncells"]
+
+        # continuity for L2 projection
+        self._export_dict["continuity"] = "C0"
+
+        # what shall be exported
+        assert self._export_dict["level"] in [
+            "centerline + directors",
+            "volume",
+            "NodalVolume",
+            "None",
+            None,
+        ]
+
+        ########################################################
+        # get number of frames for export and make cell-arrays #
+        ########################################################
+        if self._export_dict["level"] == "centerline + directors":
+            # TODO: maybe export directors with respect to their polynomialdegree (to see them at their nodes)
+            # for polynomial shape functions this should be the best.
+            # But for other interpolations (SE3) this is not good!
+
+            num_per_cell = self._export_dict["num_per_cell"]
+            if num_per_cell == "Auto":
+                p = self.polynomial_degree_r
+            else:
+                p = num_per_cell - 1
+
+            # compute number of frames
+            self._export_dict["num_frames"] = p * ncells + 1
+
+            # create cells
+            self._export_dict["cells"] = [
+                (
+                    VTK_LAGRANGE_CURVE,
+                    np.concatenate([[0], [p], np.arange(1, p)]) + i * p,
+                )
+                for i in range(ncells)
+            ]
+
+        elif self._export_dict["level"] == "volume":
+            assert isinstance(
+                self.cross_section, (ExportableCrossSection)
+            ), "Volume export is only implemented for Classes derived from ExportableCrossSection."
+
+            # always use 4 here
+            # this is only the number of points we use for the projection
+            self._export_dict["num_frames"] = 4 * ncells + 1
+
+            # make cells
+            p_cs = self.cross_section.vtk_degree
+            p_zeta = 3  # polynomial_degree of the cell along the rod. Always 3, this is hardcoded in L2_projection when BernsteinBasis is called!
+            # determines also the number of layers per cell (p_zeta + 1 = 4)
+            self._export_dict["p_zeta"] = p_zeta
+            nlayers = (p_zeta + 1) * ncells + (2 if self._export_dict["hasCap"] else 0)
+
+            higher_order_degree_main = [p_cs, p_cs, p_zeta]
+            higher_order_degree_flat = [p_cs, p_cs, 1]
+
+            # get infos from cross section
+            ppl = self.cross_section.vtk_points_per_layer
+            points_per_cell = (p_zeta + 1) * ppl
+            vtk_cell_type, connectivity_main, connectivity_flat = (
+                self.cross_section.vtk_connectivity(p_zeta)
+            )
+
+            VTK_CELL_TYPE = vtk_bezier[vtk_cell_type]
+
+            # create cells and higher_order_degrees
+            cells = []
+            higher_order_degree = []
+            # cap at xi=0
+            if self._export_dict["hasCap"]:
+                offset = -p_zeta * ppl
+                cells.append((VTK_CELL_TYPE, connectivity_flat + offset))
+                higher_order_degree.append(higher_order_degree_flat)
+
+            # iterate all cells
+            offset = ppl if self._export_dict["hasCap"] else 0
+            for i in range(ncells):
+                this_offset = i * points_per_cell + offset
+                cells.extend(
+                    [
+                        (VTK_CELL_TYPE, connectivity_main + this_offset),
+                        (VTK_CELL_TYPE, connectivity_flat + this_offset),
+                    ]
+                )
+                higher_order_degree.extend(
+                    [higher_order_degree_main, higher_order_degree_flat]
+                )
+
+            # remove cap at xi=1
+            if not self._export_dict["hasCap"]:
+                cells = cells[:-1]
+                higher_order_degree = higher_order_degree[:-1]
+
+            # Note: if there is a closed rod (ring), this should be handled here
+
+            # save for later use
+            self._export_dict["higher_order_degrees"] = higher_order_degree
+            self._export_dict["cells"] = cells
+            self._export_dict["RationalWeights"] = np.tile(
+                [self.cross_section.vtk_rational_weights], nlayers
+            ).T
+
+            ###############################
+            # assertion for stress export #
+            ###############################
+            if self._export_dict["stresses"]:
+                # TODO: remove this assertion, when we compute the stresses on element level
+                # stresses are evaluated at xis
+                # stresses are very likely to jump at xis_e_int
+                # therfore, we shouldn't evaluate them at these points
+                num = self._export_dict["num_frames"] - 1
+                xis = np.linspace(0, 1, num=num)
+                xis_e_int = np.linspace(0, 1, self.nelement + 1)[1:-1]
+                for xi_e in xis_e_int:
+                    assert (
+                        xi_e not in xis
+                    ), f"xis for fitting may not contain internal element boundaries to represent discontinuities in stresses. \nInternal boundaries at {xis_e_int}, \nxis_fitting={xis}."
+
+            #################################
+            # assertion for surface normals #
+            #################################
+            if self._export_dict["surface_normals"]:
+                assert hasattr(self.cross_section, "B_r_PQ")
+                assert hasattr(self.cross_section, "B_r_PQ_eta")
+                assert isinstance(self.cross_section, CircularCrossSection)
+                if not self._export_dict["hasCap"]:
+                    warn(
+                        "It is recommended to set 'hasCap=True' in rod._export_dict when surface normals are exported!"
+                    )
+
+        elif self._export_dict["level"] == "NodalVolume":
+            assert isinstance(
+                self.cross_section, (ExportableCrossSection)
+            ), "Volume export is only implemented for Classes derived from ExportableCrossSection."
+
+            # overwrite nCells: 1 cell for each element
+            self._export_dict["ncells"] = self.nelement
+            ncells = self._export_dict["ncells"]
+
+            # this works only, when the nodes of both fields coincide
+            assert self.polynomial_degree_r == self.polynomial_degree_p
+            p = self.polynomial_degree_r
+
+            self._export_dict["num_frames"] = p * ncells + 1
+
+            # make cells
+            p_cs = self.cross_section.vtk_degree
+            p_zeta = p  # polynomial_degree of the cell along the rod
+            self._export_dict["p_zeta"] = p_zeta
+            nlayers = (p_zeta + 1) * ncells
+
+            higher_order_degree_main = [p_cs, p_cs, p_zeta]
+
+            # get infos from cross section
+            ppl = self.cross_section.vtk_points_per_layer
+            points_per_cell = (p_zeta + 1) * ppl
+            vtk_cell_type, connectivity_main, _ = self.cross_section.vtk_connectivity(
+                p_zeta
+            )
+
+            VTK_CELL_TYPE = vtk_lagrange[vtk_cell_type]
+
+            # create cells and higher_order_degrees
+            cells = []
+            higher_order_degree = []
+
+            # iterate all cells
+            for i in range(ncells):
+                this_offset = i * (points_per_cell - ppl)
+                cells.append((VTK_CELL_TYPE, connectivity_main + this_offset))
+                higher_order_degree.append(higher_order_degree_main)
+
+            # Note: if there is a closed rod (ring), this should be handled here
+
+            # save for later use
+            self._export_dict["higher_order_degrees"] = higher_order_degree
+            self._export_dict["cells"] = cells
+
+        elif self._export_dict["level"] == "None" or self._export_dict["level"] == None:
+            self._export_dict["level"] = None
+
+        # set flag value to True
+        self.preprocessed_export = True
+
+    def export(self, sol_i, **kwargs):
         q = sol_i.q
 
-        if "num" in kwargs:
-            num = kwargs["num"]
-        else:
-            num = self.nelement * 4
+        # do the preprocess
+        # TODO: maybe call the preprocess already when the export is triggered by the system
+        if not self.preprocessed_export:
+            self.preprocess_export()
 
-        r_OPs, d1s, d2s, d3s = self.frames(q, num=num)
+        # export nothing
+        if self._export_dict["level"] == None:
+            return None, None, None, None
+
+        # get values that very computed in preprocess into local scope
+        ncells = self._export_dict["ncells"]
+        continuity = self._export_dict["continuity"]
+        level = self._export_dict["level"]
+        num_frames = self._export_dict["num_frames"]
 
         if level == "centerline + directors":
+            # get frames
+            r_OPs, d1s, d2s, d3s = self.frames(q, num=num_frames)
+
             #######################################
             # simple export of points and directors
             #######################################
-            r_OPs, d1s, d2s, d3s = self.frames(q, num=num)
-
+            # fill structs for centerline and directors
             vtk_points = r_OPs.T
-
-            cells = [(VTK_POLY_LINE, list(range(num)))]
-
-            cell_data = {}
 
             point_data = {
                 "d1": d1s.T,
                 "d2": d2s.T,
                 "d3": d3s.T,
             }
+            # TODO: add stresses here?
+            # here is a bit more work to do, as the points allow for now only C0 continuity in stresses!
+            cell_data = {}
+
+            return vtk_points, self._export_dict["cells"], point_data, cell_data
 
         elif level == "volume":
-            assert isinstance(
-                self.cross_section, (CircularCrossSection, RectangularCrossSection)
-            ), "Volume export is only implemented for CircularCrossSection and RectangularCrossSection."
+            # get frames
+            r_OPs, d1s, d2s, d3s = self.frames(q, num=num_frames)
 
             ################################
             # project on cubic Bezier volume
             ################################
-            if "n_segments" in kwargs:
-                n_segments = kwargs["n_segments"]
-            else:
-                n_segments = self.nelement
-
-            assert num >= 2 * n_segments
-
-            r_OPs, d1s, d2s, d3s = self.frames(q, num=num)
-            target_points_centerline = r_OPs.T
-
-            # create points of the target curves (three characteristic points
-            # of the cross section)
-            if isinstance(self.cross_section, CircularCrossSection):
-                if circle_as_wedge:
-                    ri = self.cross_section.radius
-                    ru = 2 * ri
-                    a = 2 * np.sqrt(3) * ri
-
-                    target_points_0 = np.array(
-                        [r_OP - ri * d3 for (r_OP, d3) in zip(r_OPs.T, d3s.T)]
-                    )
-
-                    target_points_1 = np.array(
-                        [
-                            r_OP + d2 * a / 2 - ri * d3
-                            for (r_OP, d2, d3) in zip(r_OPs.T, d2s.T, d3s.T)
-                        ]
-                    )
-
-                    target_points_2 = np.array(
-                        [r_OP + d3 * ru for (r_OP, d3) in zip(r_OPs.T, d3s.T)]
-                    )
-                else:
-                    target_points_0 = target_points_centerline
-                    target_points_1 = np.array(
-                        [
-                            r_OP + d2 * self.cross_section.radius
-                            for (r_OP, d2) in zip(r_OPs.T, d2s.T)
-                        ]
-                    )
-                    target_points_2 = np.array(
-                        [
-                            r_OP + d3 * self.cross_section.radius
-                            for (r_OP, d3) in zip(r_OPs.T, d3s.T)
-                        ]
-                    )
-            elif isinstance(self.cross_section, RectangularCrossSection):
-                target_points_0 = target_points_centerline
-                target_points_1 = np.array(
-                    [
-                        r_OP + d2 * self.cross_section.width / 2
-                        for (r_OP, d2) in zip(r_OPs.T, d2s.T)
-                    ]
-                )
-                target_points_2 = np.array(
-                    [
-                        r_OP + d3 * self.cross_section.height / 2
-                        for (r_OP, d3) in zip(r_OPs.T, d3s.T)
-                    ]
-                )
-            else:
-                raise NotImplementedError
-
-            # project target points on cubic C1 Bézier curve
-            _, _, points_segments_0 = L2_projection_Bezier_curve(
-                target_points_0, n_segments, case=continuity
-            )
-            _, _, points_segments_1 = L2_projection_Bezier_curve(
-                target_points_1, n_segments, case=continuity
-            )
-            _, _, points_segments_2 = L2_projection_Bezier_curve(
-                target_points_2, n_segments, case=continuity
+            # project directors on cubic C1 bezier curve
+            # TODO: I think there is time-saving potential in the L2_projection_Bezier_curve (e.g., the matrix A there is constant, but created and filled everytime)
+            r_OP_segments = L2_projection_Bezier_curve(
+                r_OPs.T, ncells, case=continuity
+            )[2]
+            d2_segments = L2_projection_Bezier_curve(d2s.T, ncells, case=continuity)[2]
+            d3_segments = L2_projection_Bezier_curve(d3s.T, ncells, case=continuity)[2]
+            requires_d1 = (
+                self._export_dict["volume_directors"]
+                or self._export_dict["surface_normals"]
             )
 
-            if isinstance(self.cross_section, CircularCrossSection):
-                if circle_as_wedge:
+            if requires_d1:
+                d1_segments = L2_projection_Bezier_curve(
+                    d1s.T, ncells, case=continuity
+                )[2]
 
-                    def compute_missing_points(segment, layer):
-                        P0 = points_segments_0[segment, layer]
-                        P3 = points_segments_1[segment, layer]
-                        P4 = points_segments_2[segment, layer]
+            # get characteristic points from the cross-section
+            compute_points = self.cross_section.vtk_compute_points(
+                r_OP_segments, d2_segments, d3_segments, vtk_bezier
+            )
 
-                        P5 = 2 * P0 - P3
-                        P1 = 0.5 * (P3 + P4)
-                        P0 = 0.5 * (P5 + P3)
-                        P2 = 0.5 * (P4 + P5)
+            # get some values for shortcuts
+            ppl = self.cross_section.vtk_points_per_layer
+            p_zeta = self._export_dict["p_zeta"]
 
-                        dim = len(P0)
-                        points_weights = np.zeros((6, dim + 1))
-                        points_weights[0] = np.array([*P0, 1])
-                        points_weights[1] = np.array([*P1, 1])
-                        points_weights[2] = np.array([*P2, 1])
-                        points_weights[3] = np.array([*P3, 1 / 2])
-                        points_weights[4] = np.array([*P4, 1 / 2])
-                        points_weights[5] = np.array([*P5, 1 / 2])
+            ##################
+            # compute points #
+            ##################
+            vtk_points = []
+            # cap at xi=0
+            if self._export_dict["hasCap"]:
+                vtk_points.extend(compute_points(0, 0))
 
-                        return points_weights
+            # iterate all cells
+            for i in range(ncells):
+                # iterate all layers
+                for layer in range(p_zeta + 1):
+                    vtk_points.extend(compute_points(i, layer))
 
-                    # create correct VTK ordering, see
-                    # https://coreform.com/papers/implementation-of-rational-bezier-cells-into-VTK-report.pdf:
-                    vtk_points_weights = []
-                    for i in range(n_segments):
-                        # compute all missing points of the layer
-                        points_layer0 = compute_missing_points(i, 0)
-                        points_layer1 = compute_missing_points(i, 1)
-                        points_layer2 = compute_missing_points(i, 2)
-                        points_layer3 = compute_missing_points(i, 3)
+            # cap at xi=1
+            if self._export_dict["hasCap"]:
+                vtk_points.extend(compute_points(-1, -1))
 
-                        #######################
-                        # 1. vertices (corners)
-                        #######################
+            # points to export in numpy array
+            vtk_points = np.array(vtk_points)
 
-                        # bottom
-                        for j in range(3):
-                            vtk_points_weights.append(points_layer0[j])
-
-                        # top
-                        for j in range(3):
-                            vtk_points_weights.append(points_layer3[j])
-
-                        ##########
-                        # 2. edges
-                        ##########
-
-                        # bottom
-                        for j in range(3, 6):
-                            vtk_points_weights.append(points_layer0[j])
-
-                        # top
-                        for j in range(3, 6):
-                            vtk_points_weights.append(points_layer3[j])
-
-                        # first and second
-                        for j in range(3):
-                            vtk_points_weights.append(points_layer1[j])
-                            vtk_points_weights.append(points_layer2[j])
-
-                        ##########
-                        # 3. faces
-                        ##########
-
-                        # first and second
-                        for j in range(3, 6):
-                            vtk_points_weights.append(points_layer1[j])
-                            vtk_points_weights.append(points_layer2[j])
-                else:
-
-                    def compute_missing_points(segment, layer):
-                        P2 = points_segments_2[segment, layer]
-                        P1 = points_segments_1[segment, layer]
-                        P8 = points_segments_0[segment, layer]
-                        P0 = 2 * P8 - P2
-                        P3 = 2 * P8 - P1
-                        P4 = (P0 + P1) - P8
-                        P5 = (P1 + P2) - P8
-                        P6 = (P2 + P3) - P8
-                        P7 = (P3 + P0) - P8
-
-                        dim = len(P0)
-                        s22 = np.sqrt(2) / 2
-                        points_weights = np.zeros((9, dim + 1))
-                        points_weights[0] = np.array([*P0, 1])
-                        points_weights[1] = np.array([*P1, 1])
-                        points_weights[2] = np.array([*P2, 1])
-                        points_weights[3] = np.array([*P3, 1])
-                        points_weights[4] = np.array([*P4, s22])
-                        points_weights[5] = np.array([*P5, s22])
-                        points_weights[6] = np.array([*P6, s22])
-                        points_weights[7] = np.array([*P7, s22])
-                        points_weights[8] = np.array([*P8, 1])
-
-                        return points_weights
-
-                    # create correct VTK ordering, see
-                    # https://coreform.com/papers/implementation-of-rational-bezier-cells-into-VTK-report.pdf:
-                    vtk_points_weights = []
-                    for i in range(n_segments):
-                        # compute all missing points of the layer
-                        points_layer0 = compute_missing_points(i, 0)
-                        points_layer1 = compute_missing_points(i, 1)
-                        points_layer2 = compute_missing_points(i, 2)
-                        points_layer3 = compute_missing_points(i, 3)
-
-                        #######################
-                        # 1. vertices (corners)
-                        #######################
-
-                        # bottom
-                        for j in range(4):
-                            vtk_points_weights.append(points_layer0[j])
-
-                        # top
-                        for j in range(4):
-                            vtk_points_weights.append(points_layer3[j])
-
-                        ##########
-                        # 2. edges
-                        ##########
-
-                        # bottom
-                        for j in range(4, 8):
-                            vtk_points_weights.append(points_layer0[j])
-
-                        # top
-                        for j in range(4, 8):
-                            vtk_points_weights.append(points_layer3[j])
-
-                        # first and second
-                        # for j in [0, 1, 3, 2]:  # ordering for vtu file version<2.0, e.g. 0.1
-                        for j in range(4):  # ordering for vtu file version>=2.0
-                            vtk_points_weights.append(points_layer1[j])
-                            vtk_points_weights.append(points_layer2[j])
-
-                        ##########
-                        # 3. faces
-                        ##########
-
-                        # first and second
-                        for j in [7, 5, 4, 6]:
-                            vtk_points_weights.append(points_layer1[j])
-                            vtk_points_weights.append(points_layer2[j])
-
-                        # bottom and top
-                        vtk_points_weights.append(points_layer0[0])
-                        vtk_points_weights.append(points_layer3[-1])
-
-                        ############
-                        # 3. volumes
-                        ############
-
-                        # first and second
-                        vtk_points_weights.append(points_layer1[0])
-                        vtk_points_weights.append(points_layer2[-1])
-
-            elif isinstance(self.cross_section, RectangularCrossSection):
-
-                def compute_missing_points(segment, layer):
-                    Q0 = points_segments_0[segment, layer]
-                    Q1 = points_segments_1[segment, layer]
-                    Q2 = points_segments_2[segment, layer]
-                    P0 = Q0 - (Q2 - Q0) - (Q1 - Q0)
-                    P1 = Q0 - (Q2 - Q0) + (Q1 - Q0)
-                    P2 = Q0 + (Q2 - Q0) + (Q1 - Q0)
-                    P3 = Q0 + (Q2 - Q0) - (Q1 - Q0)
-
-                    dim = len(P0)
-                    points_weights = np.zeros((4, dim + 1))
-                    points_weights[0] = np.array([*P0, 1])
-                    points_weights[1] = np.array([*P1, 1])
-                    points_weights[2] = np.array([*P2, 1])
-                    points_weights[3] = np.array([*P3, 1])
-
-                    return points_weights
-
-                # create correct VTK ordering, see
-                # https://coreform.com/papers/implementation-of-rational-bezier-cells-into-VTK-report.pdf:
-                vtk_points_weights = []
-                for i in range(n_segments):
-                    # compute all missing points of the layer
-                    points_layer0 = compute_missing_points(i, 0)
-                    points_layer1 = compute_missing_points(i, 1)
-                    points_layer2 = compute_missing_points(i, 2)
-                    points_layer3 = compute_missing_points(i, 3)
-
-                    #######################
-                    # 1. vertices (corners)
-                    #######################
-
-                    # bottom
-                    for j in range(4):
-                        vtk_points_weights.append(points_layer0[j])
-
-                    # top
-                    for j in range(4):
-                        vtk_points_weights.append(points_layer3[j])
-
-                    ##########
-                    # 2. edges
-                    ##########
-                    # first and second
-                    # for j in [0, 1, 3, 2]:  # ordering for vtu file version<2.0, e.g. 0.1
-                    for j in range(4):  # ordering for vtu file version>=2.0
-                        vtk_points_weights.append(points_layer1[j])
-                        vtk_points_weights.append(points_layer2[j])
-
-            p_zeta = 3
-            if isinstance(self.cross_section, CircularCrossSection):
-                if circle_as_wedge:
-                    n_layer = 6
-                    n_cell = (p_zeta + 1) * n_layer
-
-                    higher_order_degrees = np.array([[2, 2, p_zeta]] * n_segments)
-
-                    cells = [
-                        (
-                            VTK_BEZIER_WEDGE,
-                            np.arange(i * n_cell, (i + 1) * n_cell),
-                        )
-                        for i in range(n_segments)
-                    ]
-                else:
-                    n_layer = 9
-                    n_cell = (p_zeta + 1) * n_layer
-
-                    higher_order_degrees = np.array([[2, 2, p_zeta]] * n_segments)
-
-                    cells = [
-                        (
-                            VTK_BEZIER_HEXAHEDRON,
-                            np.arange(i * n_cell, (i + 1) * n_cell),
-                        )
-                        for i in range(n_segments)
-                    ]
-            if isinstance(self.cross_section, RectangularCrossSection):
-                n_layer = 4
-                n_cell = (p_zeta + 1) * n_layer
-
-                higher_order_degrees = np.array([[1, 1, p_zeta]] * n_segments)
-
-                cells = [
-                    (
-                        VTK_BEZIER_HEXAHEDRON,
-                        np.arange(i * n_cell, (i + 1) * n_cell),
-                    )
-                    for i in range(n_segments)
-                ]
-
-            vtk_points_weights = np.array(vtk_points_weights)
-            vtk_points = vtk_points_weights[:, :3]
-
-            if isinstance(self.cross_section, RectangularCrossSection):
-                point_data = {
-                    "RationalWeights": vtk_points_weights[:, 3, None],
-                }
-            else:
-                point_data = {
-                    "RationalWeights": vtk_points_weights[:, 3, None],
-                }
-
-            cell_data = {
-                "HigherOrderDegrees": higher_order_degrees,
+            # rational weights for NURBS
+            point_data = {
+                "RationalWeights": self._export_dict["RationalWeights"],
             }
 
-        else:
-            raise NotImplementedError
+            ###################
+            # add points data #
+            ###################
+            # streses
+            if self._export_dict["stresses"]:
+                # TODO: do this on element basis when eval_stresses accepts el as argument
+                # This needs than a general rewriting!
+                num_stresses = num_frames - 1
+                xis = np.linspace(0, 1, num=num_stresses)
+                B_ns = np.zeros([3, num_stresses])
+                B_ms = np.zeros([3, num_stresses])
 
-        return vtk_points, cells, point_data, cell_data
+                t = sol_i.t
+                la_c = sol_i.la_c
+                la_g = sol_i.la_g
+                for j in range(num_stresses):
+                    B_ns[:, j], B_ms[:, j] = self.eval_stresses(
+                        t, q, la_c, la_g, xis[j], el=None
+                    )
+
+                # project contact forces and moments on cubic C1 bezier curve
+                B_n_segments = L2_projection_Bezier_curve(
+                    B_ns.T,
+                    ncells,
+                    case="C-1",
+                )[2]
+                B_m_segments = L2_projection_Bezier_curve(
+                    B_ms.T,
+                    ncells,
+                    case="C-1",
+                )[2]
+
+                # fill lists
+                vtk_B_n = []
+                vtk_B_m = []
+                # cap at xi=0
+                if self._export_dict["hasCap"]:
+                    vtk_B_n.extend(np.repeat([B_n_segments[0, 0]], ppl, axis=0))
+                    vtk_B_m.extend(np.repeat([B_m_segments[0, 0]], ppl, axis=0))
+
+                # iterate all cells
+                for i in range(ncells):
+                    # iterate all layers
+                    for layer in range(p_zeta + 1):
+                        vtk_B_n.extend(np.repeat([B_n_segments[i, layer]], ppl, axis=0))
+                        vtk_B_m.extend(np.repeat([B_m_segments[i, layer]], ppl, axis=0))
+
+                # cap at xi=1
+                if self._export_dict["hasCap"]:
+                    vtk_B_n.extend(np.repeat([B_n_segments[-1, -1]], ppl, axis=0))
+                    vtk_B_m.extend(np.repeat([B_m_segments[-1, -1]], ppl, axis=0))
+
+                # add them to dictionary with point data
+                point_data["B_n"] = vtk_B_n
+                point_data["B_m"] = vtk_B_m
+
+            # volume directors
+            if self._export_dict["volume_directors"]:
+                vtk_d1 = []
+                vtk_d2 = []
+                vtk_d3 = []
+                # cap at xi=0
+                if self._export_dict["hasCap"]:
+                    vtk_d1.extend(np.repeat([d1_segments[0, 0]], ppl, axis=0))
+                    vtk_d2.extend(np.repeat([d2_segments[0, 0]], ppl, axis=0))
+                    vtk_d3.extend(np.repeat([d3_segments[0, 0]], ppl, axis=0))
+
+                # iterate all cells
+                for i in range(ncells):
+                    # iterate all layers
+                    for layer in range(p_zeta + 1):
+                        vtk_d1.extend(np.repeat([d1_segments[i, layer]], ppl, axis=0))
+                        vtk_d2.extend(np.repeat([d2_segments[i, layer]], ppl, axis=0))
+                        vtk_d3.extend(np.repeat([d3_segments[i, layer]], ppl, axis=0))
+
+                # cap at xi=1
+                if self._export_dict["hasCap"]:
+                    vtk_d1.extend(np.repeat([d1_segments[-1, -1]], ppl, axis=0))
+                    vtk_d2.extend(np.repeat([d2_segments[-1, -1]], ppl, axis=0))
+                    vtk_d3.extend(np.repeat([d3_segments[-1, -1]], ppl, axis=0))
+
+                # add them to dictionary with point data
+                point_data["d1"] = vtk_d1
+                point_data["d2"] = vtk_d2
+                point_data["d3"] = vtk_d3
+
+            # surface normals
+            if self._export_dict["surface_normals"]:
+                # eta values of the points in each layer
+                etas = self.cross_section.point_etas
+                vtk_surface_normals = []
+                # cap at xi=0
+                if self._export_dict["hasCap"]:
+                    vtk_surface_normals.extend(
+                        np.repeat([-d1_segments[0, 0]], ppl, axis=0)
+                    )
+
+                # iterate all cells
+                for i in range(ncells):
+                    # iterate all layers
+                    for layer in range(p_zeta + 1):
+                        el = i
+                        xi = (i + layer / p_zeta) / ncells
+                        # TODO: do this cleaner (computation of el)
+                        for point in range(ppl):
+                            vtk_surface_normals.append(
+                                self.surface_normal(q, xi, etas[point], el)
+                            )
+
+                # cap at xi=1
+                if self._export_dict["hasCap"]:
+                    vtk_surface_normals.extend(
+                        np.repeat([d1_segments[-1, -1]], ppl, axis=0)
+                    )
+
+                # TODO: Do we also need to project them?
+
+                # add them to dictionary with point data
+                point_data["surface_normal"] = vtk_surface_normals
+
+            #################
+            # add cell data #
+            #################
+            cell_data = {
+                "HigherOrderDegrees": self._export_dict["higher_order_degrees"],
+            }
+
+        elif level == "NodalVolume":
+            # get frames
+            r_OPs, d1s, d2s, d3s = self.nodalFrames(q)
+
+            # get characteristic points from the cross-section
+            compute_points = self.cross_section.vtk_compute_points(
+                np.array([r_OPs]), np.array([d2s]), np.array([d3s]), vtk_lagrange
+            )
+
+            # get some values for shortcuts
+            ppl = self.cross_section.vtk_points_per_layer
+            p_zeta = self._export_dict["p_zeta"]
+
+            ##################
+            # compute points #
+            ##################
+            vtk_points = np.vstack([compute_points(0, i) for i in range(num_frames)])
+
+            ###################
+            # add points data #
+            ###################
+            point_data = {}
+
+            #################
+            # add cell data #
+            #################
+            cell_data = {
+                "HigherOrderDegrees": self._export_dict["higher_order_degrees"],
+            }
+
+        return vtk_points, self._export_dict["cells"], point_data, cell_data

--- a/cardillo/rods/_base_export.py
+++ b/cardillo/rods/_base_export.py
@@ -1,8 +1,6 @@
 from abc import ABC, abstractmethod
 import numpy as np
-from vtk import (
-    VTK_LAGRANGE_CURVE,
-)
+from vtk import VTK_LAGRANGE_CURVE
 from warnings import warn
 
 from cardillo.utility.bezier import L2_projection_Bezier_curve
@@ -111,8 +109,6 @@ class RodExportBase(ABC):
         eval = self._eval(qp, xi, N, N_xi)
         r_OP = eval[0]
         A_IB = eval[1]
-        # B_gamma = eval[2]
-        # B_kappa_IB = eval[3]
 
         B_r_PQ = self.cross_section.B_r_PQ(eta)
 
@@ -124,7 +120,6 @@ class RodExportBase(ABC):
         qp = q_body[self.elDOF[el]]
         N, N_xi = self.basis_functions_r(xi, el)
         eval = self._eval(qp, xi, N, N_xi)
-        # r_OP = eval[0]
         A_IB = eval[1]
         B_gamma = eval[2]
         B_kappa_IB = eval[3]
@@ -261,7 +256,7 @@ class RodExportBase(ABC):
             # assertion for stress export #
             ###############################
             if self._export_dict["stresses"]:
-                # TODO: remove this assertion, when we compute the stresses on element level
+                # TODO: remove this assertion, when we can do the projection also on element level
                 # stresses are evaluated at xis
                 # stresses are very likely to jump at xis_e_int
                 # therfore, we shouldn't evaluate them at these points
@@ -438,7 +433,7 @@ class RodExportBase(ABC):
             ###################
             # streses
             if self._export_dict["stresses"]:
-                # TODO: do this on element basis when eval_stresses accepts el as argument
+                # TODO: do this on element basiswhen we can do the projection also on element level
                 # This needs than a general rewriting!
                 num_stresses = num_frames - 1
                 xis = np.linspace(0, 1, num=num_stresses)

--- a/cardillo/rods/_cross_section.py
+++ b/cardillo/rods/_cross_section.py
@@ -1,5 +1,22 @@
 from abc import ABC, abstractmethod
+from collections import namedtuple
+from enum import IntEnum
 import numpy as np
+from vtk import (
+    VTK_BEZIER_HEXAHEDRON,
+    VTK_BEZIER_WEDGE,
+    VTK_LAGRANGE_HEXAHEDRON,
+    VTK_LAGRANGE_WEDGE,
+)
+
+
+vtk_types = IntEnum(
+    "VTK_TYPES",
+    [("Hexahedron", 0), ("Wedge", 1)],
+)
+vtk_interpolation = namedtuple("vtk_interpolation", ["Hexahedron", "Wedge"])
+vtk_bezier = vtk_interpolation(VTK_BEZIER_HEXAHEDRON, VTK_BEZIER_WEDGE)
+vtk_lagrange = vtk_interpolation(VTK_LAGRANGE_HEXAHEDRON, VTK_LAGRANGE_WEDGE)
 
 
 class CrossSection(ABC):
@@ -22,6 +39,28 @@ class CrossSection(ABC):
     def second_moment(self):
         """Matrix containing the second moments of area."""
         ...
+
+
+class ExportableCrossSection(CrossSection):
+    @property
+    @abstractmethod
+    def vtk_degree(self): ...
+
+    @property
+    @abstractmethod
+    def vtk_points_per_layer(self): ...
+
+    @property
+    @abstractmethod
+    def vtk_rational_weights(self): ...
+
+    @abstractmethod
+    def vtk_compute_points(
+        self, r_OP_segments, d2_segments, d3_segments, interpolation=vtk_bezier
+    ): ...
+
+    @abstractmethod
+    def vtk_connectivity(self, p_zeta): ...
 
 
 class UserDefinedCrossSection(CrossSection):
@@ -54,8 +93,8 @@ class UserDefinedCrossSection(CrossSection):
         return self._second_moment
 
 
-class CircularCrossSection(CrossSection):
-    def __init__(self, radius):
+class CircularCrossSection(ExportableCrossSection):
+    def __init__(self, radius, *, export_as_wedge=True):
         """Circular cross-section.
 
         Parameters
@@ -69,6 +108,9 @@ class CircularCrossSection(CrossSection):
         self._first_moment = np.zeros(3)
         # https://en.wikipedia.org/wiki/List_of_second_moments_of_area
         self._second_moment = np.diag([2, 1, 1]) / 4 * np.pi * radius**4
+
+        self.circle_as_wedge = export_as_wedge
+        self.compute_my_alphas()
 
     @property
     def area(self):
@@ -86,17 +128,230 @@ class CircularCrossSection(CrossSection):
     def radius(self):
         return self._radius
 
+    def compute_my_alphas(self):
+        # alpha measures the angle to d2
+        if self.circle_as_wedge:
+            self.alphas = [
+                np.pi * 3 / 2,
+                np.pi / 6,
+                np.pi * 5 / 6,
+                np.pi * 11 / 6,
+                np.pi / 2,
+                np.pi * 7 / 6,
+            ]
 
-class RectangularCrossSection(CrossSection):
+        else:
+            self.alphas = [
+                np.pi * 3 / 2,
+                0,
+                np.pi / 2,
+                np.pi,
+                np.pi * 7 / 4,
+                np.pi / 4,
+                np.pi * 3 / 4,
+                np.pi * 5 / 4,
+                0,
+            ]
+
+    @property
+    def point_etas(self):
+        return self.alphas
+
+    def B_r_PQ(self, eta):
+        return self.radius * np.array([0, np.cos(eta), np.sin(eta)])
+
+    def B_r_PQ_eta(self, eta):
+        return self.radius * np.array([0, -np.sin(eta), np.cos(eta)])
+
+    @property
+    def vtk_degree(self):
+        return 2
+
+    @property
+    def vtk_points_per_layer(self):
+        if self.circle_as_wedge:
+            return 6
+        else:
+            return 9
+
+    def vtk_connectivity(self, p_zeta):
+        nlayers = p_zeta + 1
+        ppl = self.vtk_points_per_layer
+        npoints = nlayers * ppl
+
+        numbered_layers = np.array(
+            [np.arange(ppl * layer, ppl * (layer + 1)) for layer in range(p_zeta + 1)]
+        )
+
+        if self.circle_as_wedge:
+            vtk_cell_type = vtk_types.Wedge
+            # fmt: off
+            connectivity_main = np.concatenate(
+                [
+                    numbered_layers[0, :3],     # vertices bottom
+                    numbered_layers[-1, :3],    # vertices top
+                    numbered_layers[0, 3:],     # edges bottom
+                    numbered_layers[-1, 3:],    # edges top
+                    numbered_layers[1:-1, 0],   # edge1 middle
+                    numbered_layers[1:-1, 1],   # edge2 middle
+                    numbered_layers[1:-1, 2],   # edge3 middle
+                    numbered_layers[1:-1, 3],   # faces1 middle
+                    numbered_layers[1:-1, 4],   # faces2 middle
+                    numbered_layers[1:-1, 5],   # faces3 middle
+                ]
+            )
+            connectivity_flat = np.concatenate(
+                [
+                    numbered_layers[-1, :3],    # vertices top (last)
+                    np.arange(0, 3) + npoints,  # vertices bottom (next)
+                    numbered_layers[-1, 3:],    # edges top (last)
+                    np.arange(3, 6) + npoints,  # edges bottom (next)  
+                ]
+            )
+            # fmt: on
+        else:
+            vtk_cell_type = vtk_types.Hexahedron
+
+            # fmt: off
+            connectivity_main = np.concatenate(
+                [
+                    numbered_layers[0, :4],     # vertices bottom
+                    numbered_layers[-1, :4],    # vertices top
+                    numbered_layers[0, 4:-1],   # edges bottom
+                    numbered_layers[-1, 4:-1],  # edges top
+                    numbered_layers[1:-1,0],    # edges middle 0
+                    numbered_layers[1:-1,1],    # edges middle 1
+                    numbered_layers[1:-1,2],    # edges middle 2
+                    numbered_layers[1:-1,3],    # edges middle 3
+                    numbered_layers[1:-1,7],    # faces middle 7
+                    numbered_layers[1:-1,5],    # faces middle 5
+                    numbered_layers[1:-1,4],    # faces middle 4
+                    numbered_layers[1:-1,6],    # faces middle 6
+                    [numbered_layers[0,-1]],    # face bottom
+                    [numbered_layers[-1,-1]],   # face top
+                    numbered_layers[1:-1,-1],   # volume middle 8
+                ]
+            )
+            connectivity_flat = np.concatenate(
+                [
+                    numbered_layers[-1, :4],    # vertices top (last)
+                    np.arange(0, 4) + npoints,  # vertices bottom (next)
+                    numbered_layers[-1, 4:-1],  # edges top (last)
+                    np.arange(4, 8) + npoints,  # edges bottom (next)
+                    [npoints],                  # face top (last)
+                    [npoints + ppl - 1],        # face bottom (next)   
+                ]
+            )
+            # fmt: on
+
+        return vtk_cell_type, connectivity_main, connectivity_flat
+
+    @property
+    def vtk_rational_weights(self):
+        if self.circle_as_wedge:
+            return np.array([1, 1, 1, 1 / 2, 1 / 2, 1 / 2])
+        else:
+            s22 = np.sqrt(2) / 2
+            return np.array([1, 1, 1, 1, s22, s22, s22, s22, 1])
+
+    def vtk_compute_points(
+        self, r_OP_segments, d2_segments, d3_segments, interpolation=vtk_bezier
+    ):
+        if self.circle_as_wedge:
+
+            # points:
+            #         ^ d3
+            #         |
+            #         x  P4
+            #       / | \
+            #      /-----\
+            # P2  x   |   x  P1
+            #    /|---o---|\--> d2
+            #   / \   |   / \
+            #  x---\--x--/---x
+            #  P5     P0     P3
+            #
+            # P0-P1-P2 form the inner equilateral triangle. Later refered to as points for layer 0 and 3 or edges for layer 1 and 2. They are weighted with 1
+            # P3-P4-P5 from the outer equilateral traingle. Later refered to as edges for layer 0 and 3 or faces for layer 1 and 2. They are weighted with 1/2
+
+            # radii
+            ri = self.radius
+            sa = ri / 2
+            ca = ri * np.sqrt(3) / 2
+
+            def compute_points(segment, layer):
+                r_OP = r_OP_segments[segment, layer]
+                d2 = d2_segments[segment, layer]
+                d3 = d3_segments[segment, layer]
+
+                P0 = r_OP - ri * d3
+                P1 = r_OP + ca * d2 + sa * d3
+                P2 = r_OP - ca * d2 + sa * d3
+
+                if interpolation == vtk_bezier:
+                    P3 = r_OP + 2 * ca * d2 - ri * d3
+                    P4 = r_OP + 2 * ri * d3
+                    P5 = r_OP - 2 * ca * d2 - ri * d3
+
+                elif interpolation == vtk_lagrange:
+                    # set P3, P4, P5 on the circle
+                    P3 = r_OP + ca * d2 - sa * d3
+                    P4 = r_OP + ri * d3
+                    P5 = r_OP - ca * d2 - sa * d3
+
+                return np.vstack([P0, P1, P2, P3, P4, P5])
+
+            return compute_points
+
+        else:
+
+            sqrt2_inv = 1 / np.sqrt(2)
+
+            def compute_points(segment, layer):
+                r_OP = r_OP_segments[segment, layer]
+                d2 = d2_segments[segment, layer]
+                d3 = d3_segments[segment, layer]
+
+                rd2 = d2 * self.radius
+                rd3 = d3 * self.radius
+
+                # points on the circle
+                P0 = r_OP - rd3
+                P1 = r_OP + rd2
+                P2 = r_OP + rd3
+                P3 = r_OP - rd2
+
+                if interpolation == vtk_bezier:
+                    # points on the outer square
+                    P4 = r_OP - rd3 + rd2
+                    P5 = r_OP + rd2 + rd3
+                    P6 = r_OP + rd3 - rd2
+                    P7 = r_OP - rd2 - rd3
+                elif interpolation == vtk_lagrange:
+                    # points on the circle
+                    P4 = r_OP + (rd2 - rd3) * sqrt2_inv
+                    P5 = r_OP + (rd2 + rd3) * sqrt2_inv
+                    P6 = r_OP + (rd3 - rd2) * sqrt2_inv
+                    P7 = r_OP - (rd2 + rd3) * sqrt2_inv
+
+                # center point
+                P8 = r_OP
+
+                return np.vstack([P0, P1, P2, P3, P4, P5, P6, P7, P8])
+
+            return compute_points
+
+
+class RectangularCrossSection(ExportableCrossSection):
     def __init__(self, width, height):
         """Rectangular cross-section.
 
         Parameters:
         -----
         width : float
-            Cross-section dimension in in e_y^K-direction.
+            Cross-section dimension in in e_y^B-direction.
         height : float
-            Cross-section dimension in in e_z^K-direction.
+            Cross-section dimension in in e_z^B-direction.
         """
         self._width = width
         self._height = height
@@ -135,6 +390,78 @@ class RectangularCrossSection(CrossSection):
     def height(self):
         return self._height
 
+    @property
+    def vtk_degree(self):
+        return 1
+
+    @property
+    def vtk_points_per_layer(self):
+        return 4
+
+    def vtk_connectivity(self, p_zeta):
+        nlayers = p_zeta + 1
+        ppl = self.vtk_points_per_layer
+        npoints = nlayers * ppl
+
+        numbered_layers = np.array(
+            [np.arange(ppl * layer, ppl * (layer + 1)) for layer in range(p_zeta + 1)]
+        )
+
+        vtk_cell_type = vtk_types.Hexahedron
+        # fmt: off
+        connectivity_main = np.concatenate(
+            [
+                numbered_layers[0, :4],     # vertices bottom
+                numbered_layers[-1, :4],    # vertices top
+                numbered_layers[1:-1,0],    # edges middle 0
+                numbered_layers[1:-1,1],    # edges middle 1
+                numbered_layers[1:-1,2],    # edges middle 2
+                numbered_layers[1:-1,3],    # edges middle 3
+            ]
+        )
+        connectivity_flat = np.concatenate(
+            [
+                numbered_layers[-1, :4],    # vertices top (last)
+                np.arange(0, 4) + npoints,  # vertices bottom (next)
+            ]
+        )
+        # fmt: on
+
+        return vtk_cell_type, connectivity_main, connectivity_flat
+
+    @property
+    def vtk_rational_weights(self):
+        return np.repeat(1, 4)
+
+    def vtk_compute_points(
+        self, r_OP_segments, d2_segments, d3_segments, interpolation=None
+    ):
+        def compute_points(segment, layer):
+            r_OP = r_OP_segments[segment, layer]
+            d2 = d2_segments[segment, layer]
+            d3 = d3_segments[segment, layer]
+
+            #       ^ d3
+            # P3    |     P2
+            # x-----+-----x
+            # |     |     |
+            # |-----o-----|--> d2
+            # |           |
+            # x-----------x
+            # P0          P1
+
+            r_PP2 = d2 * self.width / 2 + d3 * self.height / 2
+            r_PP1 = d2 * self.width / 2 - d3 * self.height / 2
+
+            P0 = r_OP - r_PP2
+            P1 = r_OP + r_PP1
+            P2 = r_OP + r_PP2
+            P3 = r_OP - r_PP1
+
+            return np.vstack([P0, P1, P2, P3])
+
+        return compute_points
+
 
 class CrossSectionInertias:
     def __init__(
@@ -151,7 +478,7 @@ class CrossSectionInertias:
         A_rho0 : float
             Cross-section mass density, i.e., mass per unit reference length of rod.
         B_I_rho0 : np.array(3, 3)
-            Cross-section inertia tensor represented in the cross-section-fixed K-Basis.
+            Cross-section inertia tensor represented in the cross-section-fixed B-Basis.
 
         """
         if density is None or cross_section is None:

--- a/cardillo/rods/cosseratRod.py
+++ b/cardillo/rods/cosseratRod.py
@@ -4,7 +4,8 @@ from cachetools.keys import hashkey
 
 
 from cardillo.math import (
-    ax2skew,
+    norm,
+    cross3,
     SE3,
     SE3inv,
     Exp_SE3,
@@ -15,18 +16,27 @@ from cardillo.math import (
     T_SO3_quat_P,
     Exp_SO3_quat,
     Exp_SO3_quat_p,
+    Log_SO3_quat,
 )
+from cardillo.utility.check_time_derivatives import check_time_derivatives
 
 
 from ._base import (
-    CosseratRod,
+    CosseratRodDisplacementBased,
     CosseratRodMixed,
     make_CosseratRodConstrained,
 )
 from ._cross_section import CrossSectionInertias
 
 
-def make_CosseratRod(interpolation="Quaternion", mixed=True, constraints=None):
+def make_CosseratRod(
+    *,
+    interpolation="Quaternion",
+    mixed=True,
+    constraints=None,
+    polynomial_degree=None,
+    reduced_integration=True,
+):
     """Rod factory that returns Petrov-Galerkin Cosserat rod classes.
 
     Parameters
@@ -50,11 +60,21 @@ def make_CosseratRod(interpolation="Quaternion", mixed=True, constraints=None):
         3 : kappa_1 twist.
         4 : kappa_2 flexure around e_y^K-direction.
         5 : kappa_3 flexure around e_z^K-direction.
+    polynomial_degree : int
+        Polynomial degree (p) of the interpolation of the centerline, orientation, virtual displacement and virtual rotation. If mixed or constrained: The polynomial degree for B_n and B_m is (p-1).
+        If not specified, the following values are taken in dependency of the interpolation:
+        Quaternion : p=2
+        SE3 : p=1 (only possible value)
+        R12 : p=2
+    reduced_integration : bool
+        number of integration points (m) for the spatial integration of the internal virtual work.
+        True : m = p
+        False : m = ceil((p+1)**2 / 2)
 
     Returns:
     --------
     out : CosseratRod class
-        Returns CosseratRod_Quat, CosseratRod_SE3 or CosseratRod_R12 class.
+        Returns CosseratRod class.
 
     """
     if constraints is not None:
@@ -64,44 +84,32 @@ def make_CosseratRod(interpolation="Quaternion", mixed=True, constraints=None):
             raise ValueError("constraint values must between 0 and 5")
 
     if interpolation == "Quaternion":
-        return make_CosseratRod_Quat(mixed=mixed, constraints=constraints)
+        Basis = make_CosseratRod_Quat(mixed=mixed, constraints=constraints)
+        polynomial_degree = 2 if polynomial_degree is None else polynomial_degree
     elif interpolation == "SE3":
-        return make_CosseratRod_SE3(mixed=mixed, constraints=constraints)
+        Basis = make_CosseratRod_SE3(mixed=mixed, constraints=constraints)
+        polynomial_degree = 1 if polynomial_degree is None else polynomial_degree
+        assert (
+            polynomial_degree == 1
+        ), f"SE3 interpolation works only with polynomial_degree=1"
     elif interpolation == "R12":
-        return make_CosseratRod_R12(mixed=mixed, constraints=constraints)
+        Basis = make_CosseratRod_R12(mixed=mixed, constraints=constraints)
+        polynomial_degree = 2 if polynomial_degree is None else polynomial_degree
     else:
         raise NotImplementedError(
             "This kind of interpolation function has not been implemented."
         )
 
-
-def make_CosseratRod_Quat(mixed=True, constraints=None):
-    if mixed == True:
-        if constraints == None:
-            CosseratRodBase = CosseratRodMixed
-        else:
-            CosseratRodBase = make_CosseratRodConstrained(
-                mixed=mixed, constraints=constraints
-            )
-    else:
-        if constraints == None:
-            CosseratRodBase = CosseratRod
-        else:
-            CosseratRodBase = make_CosseratRodConstrained(
-                mixed=mixed, constraints=constraints
-            )
-
-    class CosseratRod_Quat(CosseratRodBase):
+    class CosseratRod(Basis):
         def __init__(
             self,
             cross_section,
             material_model,
             nelement,
+            *,
             Q,
             q0=None,
             u0=None,
-            polynomial_degree=2,
-            reduced_integration=True,
             cross_section_inertias=CrossSectionInertias(),
         ):
             nquadrature = polynomial_degree
@@ -110,7 +118,7 @@ def make_CosseratRod_Quat(mixed=True, constraints=None):
             if not reduced_integration:
                 import warnings
 
-                warnings.warn("Quaternion interpolation: Full integration is used!")
+                warnings.warn("Full integration is used!")
                 nquadrature = nquadrature_dyn
 
             super().__init__(
@@ -127,29 +135,139 @@ def make_CosseratRod_Quat(mixed=True, constraints=None):
             )
 
         @staticmethod
+        def straight_configuration(
+            nelement,
+            L,
+            r_OP0=np.zeros(3, dtype=float),
+            A_IB0=np.eye(3, dtype=float),
+        ):
+            """Compute generalized position coordinates for straight configuration."""
+            nnodes = polynomial_degree * nelement + 1
+
+            x0 = np.linspace(0, L, num=nnodes)
+            y0 = np.zeros(nnodes)
+            z0 = np.zeros(nnodes)
+            r_OP = np.vstack((x0, y0, z0))
+            for i in range(nnodes):
+                r_OP[:, i] = r_OP0 + A_IB0 @ r_OP[:, i]
+
+            # reshape generalized coordinates to nodal ordering
+            q_r = r_OP.reshape(-1, order="C")
+
+            # extract quaternion from orientation A_IB0
+            p = Log_SO3_quat(A_IB0)
+            q_p = np.repeat(p, nnodes)
+
+            return np.concatenate([q_r, q_p])
+
+        @staticmethod
+        def deformed_configuration(
+            nelement,
+            r_OP,
+            r_OP_xi,
+            r_OP_xixi,
+            xi1,
+            r_OP0=np.zeros(3, dtype=float),
+            A_IB0=np.eye(3, dtype=float),
+        ):
+            """Compute generalized position coordinates for a pre-curved rod along curve r_OP."""
+            nnodes_r = polynomial_degree * nelement + 1
+
+            r_OP, r_OP_xi, r_OP_xixi = check_time_derivatives(r_OP, r_OP_xi, r_OP_xixi)
+
+            xis = np.linspace(0, xi1, nnodes_r)
+
+            # nodal positions and unit quaternions
+            r0 = np.zeros((3, nnodes_r))
+            p0 = np.zeros((4, nnodes_r))
+
+            for i, xii in enumerate(xis):
+                r0[:, i] = r_OP0 + A_IB0 @ r_OP(xii)
+                A_B0B = np.zeros((3, 3))
+                A_B0B[:, 0] = r_OP_xi(xii) / norm(r_OP_xi(xii))
+                A_B0B[:, 1] = r_OP_xixi(xii) / norm(r_OP_xixi(xii))
+                A_B0B[:, 2] = cross3(A_B0B[:, 0], A_B0B[:, 1])
+                A_IB = A_IB0 @ A_B0B
+                p0[:, i] = Log_SO3_quat(A_IB)
+
+            # check for the right quaternion hemisphere
+            for i in range(nnodes_r - 1):
+                inner = p0[:, i] @ p0[:, i + 1]
+                if inner < 0:
+                    p0[:, i + 1] *= -1
+
+            # reshape generalized position coordinates to nodal ordering
+            q_r = r0.reshape(-1, order="C")
+            q_p = p0.reshape(-1, order="C")
+
+            return np.concatenate([q_r, q_p])
+
+        @staticmethod
         def straight_initial_configuration(
-            polynomial_degree,
-            basis,
             nelement,
             L,
             r_OP0=np.zeros(3, dtype=float),
             A_IB0=np.eye(3, dtype=float),
             v_P0=np.zeros(3, dtype=float),
-            B_omega_IK0=np.zeros(3, dtype=float),
+            B_omega_IB0=np.zeros(3, dtype=float),
         ):
-            return CosseratRod.straight_initial_configuration(
-                polynomial_degree,
-                polynomial_degree,
-                basis,
-                basis,
-                nelement,
-                L,
-                r_OP0,
-                A_IB0,
-                v_P0,
-                B_omega_IK0,
+            """ "Compute initial generalized position and velocity coordinates for straight configuration"""
+            nnodes = polynomial_degree * nelement + 1
+
+            x0 = np.linspace(0, L, num=nnodes)
+            y0 = np.zeros(nnodes)
+            z0 = np.zeros(nnodes)
+
+            r_OP = np.vstack((x0, y0, z0))
+            for i in range(nnodes):
+                r_OP[:, i] = r_OP0 + A_IB0 @ r_OP[:, i]
+
+            # reshape generalized coordinates to nodal ordering
+            q_r = r_OP.reshape(-1, order="C")
+
+            # extract quaternion from orientation A_IB0
+            p = Log_SO3_quat(A_IB0)
+            q_p = np.repeat(p, nnodes)
+
+            ################################
+            # compute generalized velocities
+            ################################
+            # centerline velocities
+            v_P = np.zeros_like(r_OP, dtype=float)
+            for i in range(nnodes):
+                v_P[:, i] = v_P0 + cross3(A_IB0 @ B_omega_IB0, (r_OP[:, i] - r_OP0))
+
+            # reshape generalized velocity coordinates to nodal ordering
+            u_r = v_P.reshape(-1, order="C")
+
+            # all nodes share the same angular velocity
+            u_p = np.repeat(B_omega_IB0, nnodes)
+
+            q0 = np.concatenate([q_r, q_p])
+            u0 = np.concatenate([u_r, u_p])
+
+            return q0, u0
+
+    return CosseratRod
+
+
+def make_CosseratRod_Quat(mixed=True, constraints=None):
+    if mixed == True:
+        if constraints == None:
+            CosseratRodBase = CosseratRodMixed
+        else:
+            CosseratRodBase = make_CosseratRodConstrained(
+                mixed=mixed, constraints=constraints
+            )
+    else:
+        if constraints == None:
+            CosseratRodBase = CosseratRodDisplacementBased
+        else:
+            CosseratRodBase = make_CosseratRodConstrained(
+                mixed=mixed, constraints=constraints
             )
 
+    class CosseratRod_Quat(CosseratRodBase):
         @cachedmethod(
             lambda self: self._eval_cache,
             key=lambda self, qe, xi, N, N_xi: hashkey(*qe, xi),
@@ -290,90 +408,13 @@ def make_CosseratRod_SE3(mixed=True, constraints=None):
             )
     else:
         if constraints == None:
-            CosseratRodBase = CosseratRod
+            CosseratRodBase = CosseratRodDisplacementBased
         else:
             CosseratRodBase = make_CosseratRodConstrained(
                 mixed=mixed, constraints=constraints
             )
 
     class CosseratRod_SE3(CosseratRodBase):
-        def __init__(
-            self,
-            cross_section,
-            material_model,
-            nelement,
-            Q,
-            q0=None,
-            u0=None,
-            reduced_integration=True,
-            cross_section_inertias=CrossSectionInertias(),
-            **kwargs,
-        ):
-            super().__init__(
-                cross_section,
-                material_model,
-                nelement,
-                polynomial_degree=1,
-                nquadrature=1 if reduced_integration else 2,
-                Q=Q,
-                q0=q0,
-                u0=u0,
-                nquadrature_dyn=2,
-                cross_section_inertias=cross_section_inertias,
-            )
-
-        @staticmethod
-        def straight_configuration(
-            nelement,
-            L,
-            r_OP0=np.zeros(3, dtype=float),
-            A_IB0=np.eye(3, dtype=float),
-            **kwargs,
-        ):
-            return CosseratRod.straight_configuration(nelement, L, 1, r_OP0, A_IB0)
-
-        @staticmethod
-        def deformed_configuration(
-            nelement,
-            curve,
-            dcurve,
-            ddcurve,
-            xi1,
-            polynomial_degree=1,
-            r_OP0=np.zeros(3, dtype=float),
-            A_IB0=np.eye(3, dtype=float),
-        ):
-            return CosseratRod.deformed_configuration(
-                nelement,
-                curve,
-                dcurve,
-                ddcurve,
-                xi1,
-                polynomial_degree=1,
-                r_OP0=r_OP0,
-                A_IB0=A_IB0,
-            )
-
-        @staticmethod
-        def straight_initial_configuration(
-            nelement,
-            L,
-            r_OP0=np.zeros(3, dtype=float),
-            A_IB0=np.eye(3, dtype=float),
-            v_P=np.zeros(3, dtype=float),
-            B_omega_IK=np.zeros(3, dtype=float),
-            **kwargs,
-        ):
-            return CosseratRod.straight_initial_configuration(
-                nelement,
-                L,
-                polynomial_degree=1,
-                r_OP0=r_OP0,
-                A_IB0=A_IB0,
-                v_P0=v_P,
-                B_omega_IK0=B_omega_IK,
-            )
-
         @cachedmethod(
             lambda self: self._eval_cache,
             key=lambda self, qe, xi, N, N_xi: hashkey(*qe, xi),
@@ -559,47 +600,13 @@ def make_CosseratRod_R12(mixed=True, constraints=None):
             )
     else:
         if constraints == None:
-            CosseratRodBase = CosseratRod
+            CosseratRodBase = CosseratRodDisplacementBased
         else:
             CosseratRodBase = make_CosseratRodConstrained(
                 mixed=mixed, constraints=constraints
             )
 
     class CosseratRod_R12(CosseratRodBase):
-        def __init__(
-            self,
-            cross_section,
-            material_model,
-            nelement,
-            Q,
-            q0=None,
-            u0=None,
-            polynomial_degree=2,
-            reduced_integration=True,
-            cross_section_inertias=CrossSectionInertias(),
-        ):
-            nquadrature = polynomial_degree
-            nquadrature_dyn = int(np.ceil((polynomial_degree + 1) ** 2 / 2))
-
-            if not reduced_integration:
-                import warnings
-
-                warnings.warn("'R12_PetrovGalerkin': Full integration is used!")
-                nquadrature = nquadrature_dyn
-
-            super().__init__(
-                cross_section,
-                material_model,
-                nelement,
-                polynomial_degree=polynomial_degree,
-                nquadrature=nquadrature,
-                Q=Q,
-                q0=q0,
-                u0=u0,
-                nquadrature_dyn=nquadrature_dyn,
-                cross_section_inertias=cross_section_inertias,
-            )
-
         # returns interpolated positions, orientations and strains at xi in [0,1]
         @cachedmethod(
             lambda self: self._eval_cache,

--- a/cardillo/rods/cosseratRod.py
+++ b/cardillo/rods/cosseratRod.py
@@ -199,7 +199,7 @@ def make_CosseratRod(
             return np.concatenate([q_r, q_p])
 
         @staticmethod
-        def deformed_configuration(
+        def serret_frenet_configuration(
             nelement,
             r_OP,
             r_OP_xi,
@@ -208,7 +208,7 @@ def make_CosseratRod(
             r_OP0=np.zeros(3, dtype=float),
             A_IB0=np.eye(3, dtype=float),
         ):
-            """Compute generalized position coordinates for a pre-curved rod along curve r_OP."""
+            """Compute generalized position coordinates for a pre-curved rod along curve r_OP. The cross-section orientations are based on the Serret-Frenet equations."""
             nnodes_r = polynomial_degree * nelement + 1
 
             r_OP, r_OP_xi, r_OP_xixi = check_time_derivatives(r_OP, r_OP_xi, r_OP_xixi)

--- a/cardillo/rods/cosseratRod.py
+++ b/cardillo/rods/cosseratRod.py
@@ -111,7 +111,44 @@ def make_CosseratRod(
             q0=None,
             u0=None,
             cross_section_inertias=CrossSectionInertias(),
+            name="Cosserat_rod",
         ):
+            """Base class for Petrov-Galerkin Cosserat rod formulations with
+            quaternions for the nodal orientation parametrization.
+
+            Parameters
+            ----------
+            cross_section : CrossSection
+                Geometric cross-section properties: area, first and second moments
+                of area.
+            material_model: RodMaterialModel
+                Constitutive law of Cosserat rod which relates the rod strain
+                measures B_Gamma and B_Kappa with the contact forces B_n and couples
+                B_m in the cross-section-fixed B-basis.
+            nelement : int
+                Number of rod elements.
+            Q : np.ndarray (self.nq,)
+                Generalized position coordinates of rod in a stress-free reference
+                state. Q is a collection of nodal generalized position coordinates,
+                which are given by the Cartesian coordinates of the nodal centerline
+                point r_OP_i in R^3 together with non-unit quaternions p_i in R^4
+                representing the nodal cross-section orientation.
+            q0 : np.ndarray (self.nq,)
+                Initial generalized position coordinates of rod at time t0.
+            u0 : np.ndarray (self.nu,)
+                Initial generalized velocity coordinates of rod at time t0.
+                Generalized velocity coordinates u0 is a collection of the nodal
+                generalized velocity coordinates, which are given by the nodal
+                centerline velocity v_P_i in R^3 together with the cross-section
+                angular velocity represented in the cross-section-fixed B-basis
+                B_omega_IB.
+            cross_section_inertias : CrossSectionInertias
+                Inertia properties of cross-sections: Cross-section mass density and
+                Cross-section inertia tensor represented in the cross-section-fixed
+                B-Basis.
+            name : str
+                Name of contribution.
+            """
             nquadrature = polynomial_degree
             nquadrature_dyn = int(np.ceil((polynomial_degree + 1) ** 2 / 2))
 
@@ -132,6 +169,7 @@ def make_CosseratRod(
                 u0=u0,
                 nquadrature_dyn=nquadrature_dyn,
                 cross_section_inertias=cross_section_inertias,
+                name=name,
             )
 
         @staticmethod

--- a/cardillo/rods/cosseratRod.py
+++ b/cardillo/rods/cosseratRod.py
@@ -113,7 +113,7 @@ def make_CosseratRod(
             cross_section_inertias=CrossSectionInertias(),
             name="Cosserat_rod",
         ):
-            """Base class for Petrov-Galerkin Cosserat rod formulations with
+            """Petrov-Galerkin Cosserat rod formulations with
             quaternions for the nodal orientation parametrization.
 
             Parameters

--- a/examples/rod_export_demo/cantilever.py
+++ b/examples/rod_export_demo/cantilever.py
@@ -133,7 +133,6 @@ def cantilever(
         rod_volume_circle._export_dict["stresses"] = True
         rod_volume_circle._export_dict["volume_directors"] = True
         rod_volume_circle._export_dict["surface_normals"] = True
-        rod_volume_circle._export_dict["hasCap"] = True
         system.add(rod_volume_circle)
 
         # export with circular cross-section (wedge cells)
@@ -144,7 +143,6 @@ def cantilever(
         rod_volume_circle_wedge._export_dict["stresses"] = True
         rod_volume_circle_wedge._export_dict["volume_directors"] = True
         rod_volume_circle_wedge._export_dict["surface_normals"] = True
-        rod_volume_circle_wedge._export_dict["hasCap"] = True
         system.add(rod_volume_circle_wedge)
 
         # export only nodal quantities for fast export (rectangle)

--- a/examples/rod_export_demo/cantilever.py
+++ b/examples/rod_export_demo/cantilever.py
@@ -1,0 +1,191 @@
+from math import pi
+import matplotlib.pyplot as plt
+import numpy as np
+from pathlib import Path
+
+from cardillo import System
+from cardillo.constraints import RigidConnection
+from cardillo.forces import B_Moment, Force
+from cardillo.math import e2, e3
+from cardillo.rods import (
+    CircularCrossSection,
+    RectangularCrossSection,
+    Simo1986,
+)
+from cardillo.rods.cosseratRod import (
+    make_CosseratRod,
+)
+from cardillo.solver import Newton, SolverOptions
+
+
+""" Derived cantilever beam example. 
+Purpose is to show the different exports. And to be an example how to define the export of rods.
+"""
+
+
+def cantilever(
+    Rod,  # TODO: add type hint
+    constitutive_law=Simo1986,  # TODO: add type hint
+    *,
+    nelements: int = 10,
+    #
+    n_load_steps: int = 10,
+    load_type: str = "moment",
+    #
+    VTK_export: bool = False,
+    name: str = "simulation",
+):
+    # handle name
+    plot_name = name.replace("_", " ")
+    save_name = name.replace(" ", "_")
+
+    ############
+    # parameters
+    ############
+    # geometry of the rod
+    length = 2 * np.pi
+
+    # cross section properties only for visualization purposes
+    slenderness = 1.0e1
+    width = length / slenderness
+    cross_section_rect = RectangularCrossSection(width, width)
+    cross_section_circle = CircularCrossSection(width / 2, export_as_wedge=False)
+    cross_section_circle_wedge = CircularCrossSection(width / 2, export_as_wedge=True)
+
+    # material properties
+    Ei = np.array([5, 1, 1])
+    Fi = np.array([0.5, 2, 2])
+
+    material_model = constitutive_law(Ei, Fi)
+
+    # initialize system
+    system = System()
+
+    #####
+    # rod
+    #####
+    # compute straight initial configuration of cantilever
+    q0 = Rod.straight_configuration(nelements, length)
+    # construct cantilever
+    cantilever = Rod(
+        cross_section_rect,
+        material_model,
+        nelements,
+        Q=q0,
+        q0=q0,
+    )
+
+    ##########
+    # clamping
+    ##########
+    clamping = RigidConnection(system.origin, cantilever, xi2=0)
+    system.add(cantilever, clamping)
+
+    ###############
+    # applied loads
+    ###############
+    if load_type == "moment":
+        # moment at cantilever tip
+        m = material_model.Fi[2] * 2 * np.pi / length
+        M = lambda t: t * e3 * m
+        moment = B_Moment(M, cantilever, 1)
+        system.add(moment)
+    elif load_type == "constant_end_load":
+        # spatially fixed load at cantilever tip
+        P = lambda t: material_model.Fi[2] * (10 * t) / length**2
+        F = lambda t: -P(t) * e2
+        force = Force(F, cantilever, 3 / 4)
+        system.add(force)
+    else:
+        raise NotImplementedError
+
+    # assemble system
+    system.assemble()
+
+    ############
+    # simulation
+    ############
+    solver = Newton(system, n_load_steps=n_load_steps)  # create solver
+    sol = solver.solve()  # solve static equilibrium equations
+
+    #################
+    # post-processing
+    #################
+
+    # VTK export
+    dir_name = Path(__file__).parent
+    if VTK_export:
+        from copy import deepcopy
+
+        # export with rectangular cross-section
+        rod_volume_rectangular = deepcopy(cantilever)
+        rod_volume_rectangular.name = "cantilever_volume_rectangular"
+        rod_volume_rectangular._export_dict["level"] = "volume"
+        rod_volume_rectangular._export_dict["stresses"] = True
+        rod_volume_rectangular._export_dict["volume_directors"] = True
+        system.add(rod_volume_rectangular)
+
+        # export with circular cross-section (hexagonal cells)
+        rod_volume_circle = deepcopy(cantilever)
+        rod_volume_circle.name = "cantilever_volume_circle"
+        rod_volume_circle.cross_section = cross_section_circle
+        rod_volume_circle._export_dict["level"] = "volume"
+        rod_volume_circle._export_dict["stresses"] = True
+        rod_volume_circle._export_dict["volume_directors"] = True
+        rod_volume_circle._export_dict["surface_normals"] = True
+        rod_volume_circle._export_dict["hasCap"] = True
+        system.add(rod_volume_circle)
+
+        # export with circular cross-section (wedge cells)
+        rod_volume_circle_wedge = deepcopy(cantilever)
+        rod_volume_circle_wedge.name = "cantilever_volume_circle_wedge"
+        rod_volume_circle_wedge.cross_section = cross_section_circle_wedge
+        rod_volume_circle_wedge._export_dict["level"] = "volume"
+        rod_volume_circle_wedge._export_dict["stresses"] = True
+        rod_volume_circle_wedge._export_dict["volume_directors"] = True
+        rod_volume_circle_wedge._export_dict["surface_normals"] = True
+        rod_volume_circle_wedge._export_dict["hasCap"] = True
+        system.add(rod_volume_circle_wedge)
+
+        # export only nodal quantities for fast export (rectangle)
+        rod_NodalVolume = deepcopy(cantilever)
+        rod_NodalVolume.name = "cantilever_NodalVolume"
+        rod_NodalVolume._export_dict["level"] = "NodalVolume"
+        system.add(rod_NodalVolume)
+
+        # export only nodal quantities for fast export (circle)
+        rod_NodalVolume_circle = deepcopy(cantilever)
+        rod_NodalVolume_circle.cross_section = cross_section_circle
+        rod_NodalVolume_circle.name = "cantilever_NodalVolume_circle"
+        rod_NodalVolume_circle._export_dict["level"] = "NodalVolume"
+        system.add(rod_NodalVolume_circle)
+
+        # export only nodal quantities for fast export (circle as wedge)
+        rod_NodalVolume_circle_wedge = deepcopy(cantilever)
+        rod_NodalVolume_circle_wedge.cross_section = cross_section_circle_wedge
+        rod_NodalVolume_circle_wedge.name = "cantilever_NodalVolume_circle_wedge"
+        rod_NodalVolume_circle_wedge._export_dict["level"] = "NodalVolume"
+        system.add(rod_NodalVolume_circle_wedge)
+
+        # export only centerline & directors
+        cantilever.name = "cantilever"
+        cantilever._export_dict["level"] = "centerline + directors"
+        # this rod is already in the system
+
+        # add rods and export
+        system.export(dir_name, f"vtk/{save_name}", sol)
+
+
+if __name__ == "__main__":
+    cantilever(
+        # Rod=make_CosseratRod(interpolation="SE3", mixed=True, constraints=[0, 1, 2]),
+        # Rod=make_CosseratRod(interpolation="R12", mixed=True, constraints=[0, 1, 2]),
+        Rod=make_CosseratRod(
+            mixed=True, polynomial_degree=1
+        ),  # , constraints=[0, 1, 2]),
+        # load_type="moment",
+        load_type="constant_end_load",
+        nelements=4,
+        VTK_export=True,
+        name="Cosserat mixed",
+    )

--- a/test/test_cantilever.py
+++ b/test/test_cantilever.py
@@ -37,9 +37,7 @@ It is a test for the static analysis of all different rod formulations in their 
 def cantilever(
     Rod,
     nelements=10,
-    polynomial_degree=2,
     n_load_steps=3,
-    reduced_integration=True,
     constitutive_law=Harsch2021,
     title="set_a_plot_title",
 ):
@@ -61,9 +59,7 @@ def cantilever(
     system = System()
 
     # compute straight initial configuration of cantilever
-    q0 = Rod.straight_configuration(
-        nelements, length, polynomial_degree=polynomial_degree
-    )
+    q0 = Rod.straight_configuration(nelements, length)
     # construct cantilever
     cantilever = Rod(
         cross_section,
@@ -71,8 +67,6 @@ def cantilever(
         nelements,
         Q=q0,
         q0=q0,
-        polynomial_degree=polynomial_degree,
-        reduced_integration=reduced_integration,
     )
 
     clamping_left = RigidConnection(system.origin, cantilever, xi2=(0,))

--- a/test/test_vtk_render.py
+++ b/test/test_vtk_render.py
@@ -108,9 +108,7 @@ def cantilever(
     system = System()
 
     # compute straight initial configuration of cantilever
-    q0 = Rod.straight_configuration(
-        nelements, length, polynomial_degree=polynomial_degree
-    )
+    q0 = Rod.straight_configuration(nelements, length)
     # construct cantilever
     cantilever = Rod(
         cross_section,
@@ -118,11 +116,9 @@ def cantilever(
         nelements,
         Q=q0,
         q0=q0,
-        polynomial_degree=polynomial_degree,
-        reduced_integration=reduced_integration,
     )
 
-    clamping_left = RigidConnection(system.origin, cantilever, xi2=(0,))
+    clamping_left = RigidConnection(system.origin, cantilever, xi2=0)
 
     # assemble the system
     system.add(cantilever)
@@ -131,12 +127,12 @@ def cantilever(
     # spatially fixed load at cantilever tip
     P = lambda t: material_model.Fi[2] * (10 * t) / length**2
     F = lambda t: -P(t) * e2
-    force = Force(F, cantilever, (1,))
+    force = Force(F, cantilever, 1)
     system.add(force)
 
     # moment at cantilever tip
     M = lambda t: 2.5 * P(t) * e3
-    moment = B_Moment(M, cantilever, (1,))
+    moment = B_Moment(M, cantilever, 1)
     system.add(moment)
 
     system.assemble(options=SolverOptions(compute_consistent_initial_conditions=False))


### PR DESCRIPTION
- new interface:
  - polynomial degree and reduced integration are specified in make_rod,
  - changes calls for creation of Rod class (make_rod), creation of configurations, and rod initialization,
  - added new function for configuration (similar to pose_2q or rigid body): pose_configuration that takes r_OP0(xi), A_IB(xi),
  - renamed deformed_configuration to serret_frenet_configuration,
  - __init__ function takes name as optional keyword argument;
- updated docstrings;
- fixed eval_stresses and eval_strains;
- rewrote large parts of the rod export:
  - added more export options (surface normals for circular cross sections, stresses and strains),
  - exporting rod with Lagrangian vtk cells, completely avoiding L2 projection on Beziers, and avoiding to compute interpolated points as nodal values are directly exported,
  - constant fields are only computed once,
  - modular structure together with the cross section class,
  - added example to demonstrate export,
- adjusted interface in examples with rods.