### PR TITLE
Faster CooMatrix assembly

### DIFF
--- a/cardillo/solver/scipy_dae.py
+++ b/cardillo/solver/scipy_dae.py
@@ -98,7 +98,7 @@ class ScipyDAE:
         self.g_dot_q = self.g_dot_u = self.gamma_q = self.gamma_u = self.c_q = (
             self.c_u
         ) = None
-        self.g_q2 = self.W_g2 = self.W_gamma2 = self.W_c2 = None
+        self.M1 = self.M2 = self.g_q2 = self.W_g2 = self.W_gamma2 = self.W_c2 = None
 
         self.Jy = CooMatrix((self.ny, self.ny))
         self.Jyp = CooMatrix((self.ny, self.ny))
@@ -144,6 +144,7 @@ class ScipyDAE:
         ####################
         # equations of motion
         ####################
+        M = self.M2 = self.system.M(t, q, format="Coo", coo=self.M2)
         W_tau = self._W_tau = self.system.W_tau(t, q, format="Coo", coo=self._W_tau)
         W_g = self.W_g1 = self.system.W_g(t, q, format="Coo", coo=self.W_g1)
         W_gamma = self.W_gamma1 = self.system.W_gamma(
@@ -151,7 +152,7 @@ class ScipyDAE:
         )
         W_c = self.W_c1 = self.system.W_c(t, q, format="Coo", coo=self.W_c1)
         F[self.split[0] : self.split[1]] = (
-            self.system.M(t, q) @ u_dot
+            M.asformat("coo") @ u_dot
             - self.system.h(t, q, u)
             - W_tau.asformat("coo") @ self.system.la_tau(t, q, u)
             - W_g.asformat("coo") @ la_g
@@ -175,12 +176,12 @@ class ScipyDAE:
 
     def jac(self, t, y, yp):
         # unpack vectors
-        s1, s2, s3, s4, s5 = self.split
-        q, u = y[:s1], y[s1:s2]
-        u_dot = yp[s1:s2]
-        la_g = yp[s3:s4]
-        la_gamma = yp[s4:s5]
-        la_c = yp[s5:]
+        s0, s1, s2, s3, s4 = self.split
+        q, u = y[:s0], y[s0:s1]
+        u_dot = yp[s0:s1]
+        la_g = yp[s2:s3]
+        la_gamma = yp[s3:s4]
+        la_c = yp[s4:]
 
         # evaluate commonly used quantities
         q_dot_q = self.q_dot_q = self.system.q_dot_q(
@@ -226,7 +227,7 @@ class ScipyDAE:
         c_q = self.c_q = self.system.c_q(t, q, u, la_c, format="Coo", coo=self.c_q)
         c_u = self.c_u = self.system.c_u(t, q, u, la_c, format="Coo", coo=self.c_u)
 
-        M = self.system.M(t, q)
+        M = self.M1 = self.system.M(t, q, format="Coo", coo=self.M1)
         g_q = self.g_q2 = self.system.g_q(t, q, format="Coo", coo=self.g_q2)
         W_g = self.W_g2 = self.system.W_g(t, q, format="Coo", coo=self.W_g2)
         W_gamma = self.W_gamma2 = self.system.W_gamma(
@@ -237,49 +238,41 @@ class ScipyDAE:
         # first Jacobian w.r.t. y
         Jy = self.Jy
 
-        Jy["q_dot_q", : self.split[0], : self.split[0]] = -q_dot_q
-        Jy["q_dot_u", : self.split[0], self.split[0] : self.split[1]] = -q_dot_u
+        Jy["q_dot_q", :s0, :s0] = -q_dot_q
+        Jy["q_dot_u", :s0, s0:s1] = -q_dot_u
         # note: Here we ignore the derivative d((dg/dq)^T mu) / dq since
         # `solve_dae` already performs an inexact Newton method.
         # Jy[:self.split[0], self.split[1]:self.split[2]] = g_q_T_mu_q
 
-        Jy["Mu_q", self.split[0] : self.split[1], : self.split[0]] = Mu_q
-        Jy["h_q", self.split[0] : self.split[1], : self.split[0]] = -h_q
-        Jy["Wla_tau_q", self.split[0] : self.split[1], : self.split[0]] = -Wla_tau_q
-        Jy["Wla_gamma_q", self.split[0] : self.split[1], : self.split[0]] = -Wla_gamma_q
-        Jy["Wla_g_q", self.split[0] : self.split[1], : self.split[0]] = -Wla_g_q
-        Jy["Wla_c_q", self.split[0] : self.split[1], : self.split[0]] = -Wla_c_q
-        Jy["h_u", self.split[0] : self.split[1], self.split[0] : self.split[1]] = -h_u
-        Jy[
-            "Wla_tau_u", self.split[0] : self.split[1], self.split[0] : self.split[1]
-        ] = -Wla_tau_u
+        Jy["Mu_q", s0:s1, :s0] = Mu_q
+        Jy["h_q", s0:s1, :s0] = -h_q
+        Jy["Wla_tau_q", s0:s1, :s0] = -Wla_tau_q
+        Jy["Wla_gamma_q", s0:s1, :s0] = -Wla_gamma_q
+        Jy["Wla_g_q", s0:s1, :s0] = -Wla_g_q
+        Jy["Wla_c_q", s0:s1, :s0] = -Wla_c_q
+        Jy["h_u", s0:s1, s0:s1] = -h_u
+        Jy["Wla_tau_u", s0:s1, s0:s1] = -Wla_tau_u
 
-        Jy["g_q", self.split[1] : self.split[2], : self.split[0]] = g_q
+        Jy["g_q", s1:s2, :s0] = g_q
 
-        Jy["g_dot_q", self.split[2] : self.split[3], : self.split[0]] = g_dot_q
-        Jy["g_dot_u", self.split[2] : self.split[3], self.split[0] : self.split[1]] = (
-            g_dot_u
-        )
+        Jy["g_dot_q", s2:s3, :s0] = g_dot_q
+        Jy["g_dot_u", s2:s3, s0:s1] = g_dot_u
 
-        Jy["gamma_q", self.split[3] : self.split[4], : self.split[0]] = gamma_q
-        Jy["gamma_u", self.split[3] : self.split[4], self.split[0] : self.split[1]] = (
-            gamma_u
-        )
+        Jy["gamma_q", s3:s4, :s0] = gamma_q
+        Jy["gamma_u", s3:s4, s0:s1] = gamma_u
 
-        Jy["c_q", self.split[4] :, : self.split[0]] = c_q
-        Jy["c_u", self.split[4] :, self.split[0] : self.split[1]] = c_u
+        Jy["c_q", s4:, :s0] = c_q
+        Jy["c_u", s4:, s0:s1] = c_u
 
         # second Jacobian w.r.t. yp
         Jyp = self.Jyp
 
-        Jyp["g_q_T", : self.split[0], self.split[1] : self.split[2]] = -g_q.T
+        Jyp["g_q_T", :s0, s1:s2] = -g_q.T
 
-        Jyp["M", self.split[0] : self.split[1], self.split[0] : self.split[1]] = M
-        Jyp["W_g", self.split[0] : self.split[1], self.split[2] : self.split[3]] = -W_g
-        Jyp["W_gamma", self.split[0] : self.split[1], self.split[3] : self.split[4]] = (
-            -W_gamma
-        )
-        Jyp["W_c", self.split[0] : self.split[1], self.split[4] :] = -W_c
+        Jyp["M", s0:s1, s0:s1] = M
+        Jyp["W_g", s0:s1, s2:s3] = -W_g
+        Jyp["W_gamma", s0:s1, s3:s4] = -W_gamma
+        Jyp["W_c", s0:s1, s4:] = -W_c
 
         return Jy.asformat("coo"), Jyp.asformat("coo")
 

--- a/cardillo/solver/scipy_dae.py
+++ b/cardillo/solver/scipy_dae.py
@@ -4,6 +4,7 @@ from scipy_dae.integrate import solve_dae
 from tqdm import tqdm
 
 from cardillo.solver import Solution, SolverSummary
+from cardillo.utility.coo_matrix import CooMatrix
 
 
 # TODO:
@@ -86,6 +87,26 @@ class ScipyDAE:
         self.pbar = tqdm(total=100, leave=True)
         self.i = 0
 
+        # data allocation
+        self.F = np.zeros(self.ny, dtype=float)
+        self.g_q1 = self._W_tau = self.W_g1 = self.W_gamma1 = self.W_c1 = None
+        self.q_dot_q = self.q_dot_u = None
+
+        self.Mu_q = self.h_q = self.h_u = self.Wla_tau_q = self.Wla_tau_u = (
+            self.Wla_g_q
+        ) = self.Wla_gamma_q = self.Wla_c_q = None
+        self.g_dot_q = self.g_dot_u = self.gamma_q = self.gamma_u = self.c_q = (
+            self.c_u
+        ) = None
+        self.g_q2 = self.W_g2 = self.W_gamma2 = self.W_c2 = None
+
+        self.Jy = CooMatrix((self.ny, self.ny))
+        self.Jyp = CooMatrix((self.ny, self.ny))
+        eye_q = eye_array(self.nq)
+        c_la_c = self.system.c_la_c()
+        self.Jyp["eye_q", : self.split[0], : self.split[0]] = eye_q
+        self.Jyp["c_la_c", self.split[4] :, self.split[4] :] = c_la_c
+
     def event(self, t, y, yp):
         q, u = np.array_split(y, self.split)[:2]
         q, u = self.system.step_callback(t, q, u)
@@ -95,35 +116,47 @@ class ScipyDAE:
         # update progress bar
         i1 = int(t // self.frac)
         self.pbar.update(i1 - self.i)
-        self.pbar.set_description(f"t: {t:0.2e}s < {self.t1:0.2e}s")
+        self.pbar.set_description(f"t: {t:0.2e}s < {self.t1:0.2e}s", refresh=False)
         self.i = i1
 
         # unpack vectors
-        q, u, _, _, _, _ = np.array_split(y, self.split)
-        q_dot, u_dot, mu_g, la_g, la_gamma, la_c = np.array_split(yp, self.split)
+        s1, s2, s3, s4, s5 = self.split
+        q, u = y[:s1], y[s1:s2]
+        q_dot, u_dot, mu_g, la_g, la_gamma, la_c = (
+            yp[:s1],
+            yp[s1:s2],
+            yp[s2:s3],
+            yp[s3:s4],
+            yp[s4:s5],
+            yp[s5:],
+        )
 
         # residual
-        F = np.zeros_like(y, dtype=np.common_type(y, yp))
+        F = self.F
 
         ####################
         # kinematic equation
         ####################
+        self.g_q1 = self.system.g_q(t, q, format="Coo", coo=self.g_q1)
         F[: self.split[0]] = (
-            q_dot
-            - self.system.q_dot(t, q, u)
-            - self.system.g_q(t, q, format="csc").T @ mu_g
+            q_dot - self.system.q_dot(t, q, u) - mu_g @ self.g_q1.asformat("coo")
         )
-
         ####################
         # equations of motion
         ####################
+        W_tau = self._W_tau = self.system.W_tau(t, q, format="Coo", coo=self._W_tau)
+        W_g = self.W_g1 = self.system.W_g(t, q, format="Coo", coo=self.W_g1)
+        W_gamma = self.W_gamma1 = self.system.W_gamma(
+            t, q, format="Coo", coo=self.W_gamma1
+        )
+        W_c = self.W_c1 = self.system.W_c(t, q, format="Coo", coo=self.W_c1)
         F[self.split[0] : self.split[1]] = (
             self.system.M(t, q) @ u_dot
             - self.system.h(t, q, u)
-            - self.system.W_tau(t, q, format="csr") @ self.system.la_tau(t, q, u)
-            - self.system.W_g(t, q, format="csr") @ la_g
-            - self.system.W_gamma(t, q, format="csr") @ la_gamma
-            - self.system.W_c(t, q, format="csr") @ la_c
+            - W_tau.asformat("coo") @ self.system.la_tau(t, q, u)
+            - W_g.asformat("coo") @ la_g
+            - W_gamma.asformat("coo") @ la_gamma
+            - W_c.asformat("coo") @ la_c
         )
 
         #######################
@@ -142,80 +175,113 @@ class ScipyDAE:
 
     def jac(self, t, y, yp):
         # unpack vectors
-        q, u, _, _, _, _ = np.array_split(y, self.split)
-        q_dot, u_dot, mu_g, la_g, la_gamma, la_c = np.array_split(yp, self.split)
+        s1, s2, s3, s4, s5 = self.split
+        q, u = y[:s1], y[s1:s2]
+        u_dot = yp[s1:s2]
+        la_g = yp[s3:s4]
+        la_gamma = yp[s4:s5]
+        la_c = yp[s5:]
 
         # evaluate commonly used quantities
-        q_dot_q = self.system.q_dot_q(t, q, u)
-        q_dot_u = self.system.q_dot_u(t, q)
+        q_dot_q = self.q_dot_q = self.system.q_dot_q(
+            t, q, u, format="Coo", coo=self.q_dot_q
+        )
+        q_dot_u = self.q_dot_u = self.system.q_dot_u(
+            t, q, format="Coo", coo=self.q_dot_u
+        )
 
-        Mu_q = self.system.Mu_q(t, q, u_dot)
-        h_q = self.system.h_q(t, q, u)
-        h_u = self.system.h_u(t, q, u)
-        Wla_tau_q = self.system.Wla_tau_q(t, q, u)
-        Wla_tau_u = self.system.Wla_tau_u(t, q, u)
-        Wla_g_q = self.system.Wla_g_q(t, q, la_g)
-        Wla_gamma_q = self.system.Wla_gamma_q(t, q, la_gamma)
-        Wla_c_q = self.system.Wla_c_q(t, q, la_c)
+        Mu_q = self.Mu_q = self.system.Mu_q(t, q, u_dot, format="Coo", coo=self.Mu_q)
+        h_q = self.h_q = self.system.h_q(t, q, u, format="Coo", coo=self.h_q)
+        h_u = self.h_u = self.system.h_u(t, q, u, format="Coo", coo=self.h_u)
+        Wla_tau_q = self.Wla_tau_q = self.system.Wla_tau_q(
+            t, q, u, format="Coo", coo=self.Wla_tau_q
+        )
+        Wla_tau_u = self.Wla_tau_u = self.system.Wla_tau_u(
+            t, q, u, format="Coo", coo=self.Wla_tau_u
+        )
+        Wla_g_q = self.Wla_g_q = self.system.Wla_g_q(
+            t, q, la_g, format="Coo", coo=self.Wla_g_q
+        )
+        Wla_gamma_q = self.Wla_gamma_q = self.system.Wla_gamma_q(
+            t, q, la_gamma, format="Coo", coo=self.Wla_gamma_q
+        )
+        Wla_c_q = self.Wla_c_q = self.system.Wla_c_q(
+            t, q, la_c, format="Coo", coo=self.Wla_c_q
+        )
 
-        g_dot_q = self.system.g_dot_q(t, q, u)
-        g_dot_u = self.system.g_dot_u(t, q)
+        g_dot_q = self.g_dot_q = self.system.g_dot_q(
+            t, q, u, format="Coo", coo=self.g_dot_q
+        )
+        g_dot_u = self.g_dot_u = self.system.g_dot_u(
+            t, q, format="Coo", coo=self.g_dot_u
+        )
 
-        gamma_q = self.system.gamma_q(t, q, u)
-        gamma_u = self.system.gamma_u(t, q)
+        gamma_q = self.gamma_q = self.system.gamma_q(
+            t, q, u, format="Coo", coo=self.gamma_q
+        )
+        gamma_u = self.gamma_u = self.system.gamma_u(
+            t, q, format="Coo", coo=self.gamma_u
+        )
 
-        c_q = self.system.c_q(t, q, u, la_c)
-        c_u = self.system.c_u(t, q, u, la_c)
+        c_q = self.c_q = self.system.c_q(t, q, u, la_c, format="Coo", coo=self.c_q)
+        c_u = self.c_u = self.system.c_u(t, q, u, la_c, format="Coo", coo=self.c_u)
 
-        eye_q = eye_array(self.nq)
         M = self.system.M(t, q)
-        g_q = self.system.g_q(t, q)
-        W_g = self.system.W_g(t, q)
-        W_gamma = self.system.W_gamma(t, q)
-        W_c = self.system.W_c(t, q)
-        c_la_c = self.system.c_la_c()
+        g_q = self.g_q2 = self.system.g_q(t, q, format="Coo", coo=self.g_q2)
+        W_g = self.W_g2 = self.system.W_g(t, q, format="Coo", coo=self.W_g2)
+        W_gamma = self.W_gamma2 = self.system.W_gamma(
+            t, q, format="Coo", coo=self.W_gamma2
+        )
+        W_c = self.W_c2 = self.system.W_c(t, q, format="Coo", coo=self.W_c2)
 
         # first Jacobian w.r.t. y
-        Jy = lil_array((self.ny, self.ny))
+        Jy = self.Jy
 
-        Jy[: self.split[0], : self.split[0]] = -q_dot_q
-        Jy[: self.split[0], self.split[0] : self.split[1]] = -q_dot_u
+        Jy["q_dot_q", : self.split[0], : self.split[0]] = -q_dot_q
+        Jy["q_dot_u", : self.split[0], self.split[0] : self.split[1]] = -q_dot_u
         # note: Here we ignore the derivative d((dg/dq)^T mu) / dq since
         # `solve_dae` already performs an inexact Newton method.
         # Jy[:self.split[0], self.split[1]:self.split[2]] = g_q_T_mu_q
 
-        Jy[self.split[0] : self.split[1], : self.split[0]] = (
-            Mu_q - h_q - Wla_tau_q - Wla_gamma_q - Wla_g_q - Wla_c_q
+        Jy["Mu_q", self.split[0] : self.split[1], : self.split[0]] = Mu_q
+        Jy["h_q", self.split[0] : self.split[1], : self.split[0]] = -h_q
+        Jy["Wla_tau_q", self.split[0] : self.split[1], : self.split[0]] = -Wla_tau_q
+        Jy["Wla_gamma_q", self.split[0] : self.split[1], : self.split[0]] = -Wla_gamma_q
+        Jy["Wla_g_q", self.split[0] : self.split[1], : self.split[0]] = -Wla_g_q
+        Jy["Wla_c_q", self.split[0] : self.split[1], : self.split[0]] = -Wla_c_q
+        Jy["h_u", self.split[0] : self.split[1], self.split[0] : self.split[1]] = -h_u
+        Jy[
+            "Wla_tau_u", self.split[0] : self.split[1], self.split[0] : self.split[1]
+        ] = -Wla_tau_u
+
+        Jy["g_q", self.split[1] : self.split[2], : self.split[0]] = g_q
+
+        Jy["g_dot_q", self.split[2] : self.split[3], : self.split[0]] = g_dot_q
+        Jy["g_dot_u", self.split[2] : self.split[3], self.split[0] : self.split[1]] = (
+            g_dot_u
         )
-        Jy[self.split[0] : self.split[1], self.split[0] : self.split[1]] = (
-            -h_u - Wla_tau_u
+
+        Jy["gamma_q", self.split[3] : self.split[4], : self.split[0]] = gamma_q
+        Jy["gamma_u", self.split[3] : self.split[4], self.split[0] : self.split[1]] = (
+            gamma_u
         )
 
-        Jy[self.split[1] : self.split[2], : self.split[0]] = g_q
-
-        Jy[self.split[2] : self.split[3], : self.split[0]] = g_dot_q
-        Jy[self.split[2] : self.split[3], self.split[0] : self.split[1]] = g_dot_u
-
-        Jy[self.split[3] : self.split[4], : self.split[0]] = gamma_q
-        Jy[self.split[3] : self.split[4], self.split[0] : self.split[1]] = gamma_u
-
-        Jy[self.split[4] :, : self.split[0]] = c_q
-        Jy[self.split[4] :, self.split[0] : self.split[1]] = c_u
+        Jy["c_q", self.split[4] :, : self.split[0]] = c_q
+        Jy["c_u", self.split[4] :, self.split[0] : self.split[1]] = c_u
 
         # second Jacobian w.r.t. yp
-        Jyp = lil_array((self.ny, self.ny))
+        Jyp = self.Jyp
 
-        Jyp[: self.split[0], : self.split[0]] = eye_q
-        Jyp[: self.split[0], self.split[1] : self.split[2]] = -g_q.T
+        Jyp["g_q_T", : self.split[0], self.split[1] : self.split[2]] = -g_q.T
 
-        Jyp[self.split[0] : self.split[1], self.split[0] : self.split[1]] = M
-        Jyp[self.split[0] : self.split[1], self.split[2] : self.split[3]] = -W_g
-        Jyp[self.split[0] : self.split[1], self.split[3] : self.split[4]] = -W_gamma
-        Jyp[self.split[0] : self.split[1], self.split[4] :] = -W_c
+        Jyp["M", self.split[0] : self.split[1], self.split[0] : self.split[1]] = M
+        Jyp["W_g", self.split[0] : self.split[1], self.split[2] : self.split[3]] = -W_g
+        Jyp["W_gamma", self.split[0] : self.split[1], self.split[3] : self.split[4]] = (
+            -W_gamma
+        )
+        Jyp["W_c", self.split[0] : self.split[1], self.split[4] :] = -W_c
 
-        Jyp[self.split[4] :, self.split[4] :] = c_la_c
-
-        return Jy, Jyp
+        return Jy.asformat("coo"), Jyp.asformat("coo")
 
         # note: Keep this for debugging the Jacobian
 
@@ -249,7 +315,8 @@ class ScipyDAE:
             jac=self.jac,
             **self.kwargs,
         )
-        solver_summary.print()
+        self.pbar.close()
+        # solver_summary.print()
 
         # unpack solution
         t = sol.t

--- a/cardillo/system.py
+++ b/cardillo/system.py
@@ -66,7 +66,7 @@ class System:
 
     """
 
-    def __init__(self, t0=0, origin_size=0):
+    def __init__(self, t0=0.0, origin_size=0):
         self.t0 = t0
         self.nq = 0
         self.nu = 0
@@ -348,18 +348,20 @@ class System:
             q_dot[contr.my_qDOF] = contr.q_dot(t, q[contr.qDOF], u[contr.uDOF])
         return q_dot
 
-    def q_dot_q(self, t, q, u, format="coo"):
-        coo = CooMatrix((self.nq, self.nq))
-        for contr in self.__q_dot_q_contr:
-            coo[contr.my_qDOF, contr.qDOF] = contr.q_dot_q(
+    def q_dot_q(self, t, q, u, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nq, self.nq))
+        for i, contr in enumerate(self.__q_dot_q_contr):
+            coo[i, contr.my_qDOF, contr.qDOF] = contr.q_dot_q(
                 t, q[contr.qDOF], u[contr.uDOF]
             )
         return coo.asformat(format)
 
-    def q_dot_u(self, t, q, format="coo"):
-        coo = CooMatrix((self.nq, self.nu))
-        for contr in self.__q_dot_u_contr:
-            coo[contr.my_qDOF, contr.uDOF] = contr.q_dot_u(t, q[contr.qDOF])
+    def q_dot_u(self, t, q, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nq, self.nu))
+        for i, contr in enumerate(self.__q_dot_u_contr):
+            coo[i, contr.my_qDOF, contr.uDOF] = contr.q_dot_u(t, q[contr.qDOF])
         return coo.asformat(format)
 
     def step_callback(self, t, q, u):
@@ -396,10 +398,11 @@ class System:
         else:
             return self._M0.asformat(format)
 
-    def Mu_q(self, t, q, u, format="coo"):
-        coo = CooMatrix((self.nu, self.nq))
-        for contr in self.__Mu_q_contr:
-            coo[contr.uDOF, contr.qDOF] = contr.Mu_q(t, q[contr.qDOF], u[contr.uDOF])
+    def Mu_q(self, t, q, u, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nu, self.nq))
+        for i, contr in enumerate(self.__Mu_q_contr):
+            coo[i, contr.uDOF, contr.qDOF] = contr.Mu_q(t, q[contr.qDOF], u[contr.uDOF])
         return coo.asformat(format)
 
     def h(self, t, q, u):
@@ -408,16 +411,18 @@ class System:
             h[contr.uDOF] += contr.h(t, q[contr.qDOF], u[contr.uDOF])
         return h
 
-    def h_q(self, t, q, u, format="coo"):
-        coo = CooMatrix((self.nu, self.nq))
-        for contr in self.__h_q_contr:
-            coo[contr.uDOF, contr.qDOF] = contr.h_q(t, q[contr.qDOF], u[contr.uDOF])
+    def h_q(self, t, q, u, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nu, self.nq))
+        for i, contr in enumerate(self.__h_q_contr):
+            coo[i, contr.uDOF, contr.qDOF] = contr.h_q(t, q[contr.qDOF], u[contr.uDOF])
         return coo.asformat(format)
 
-    def h_u(self, t, q, u, format="coo"):
-        coo = CooMatrix((self.nu, self.nu))
-        for contr in self.__h_u_contr:
-            coo[contr.uDOF, contr.uDOF] = contr.h_u(t, q[contr.qDOF], u[contr.uDOF])
+    def h_u(self, t, q, u, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nu, self.nu))
+        for i, contr in enumerate(self.__h_u_contr):
+            coo[i, contr.uDOF, contr.uDOF] = contr.h_u(t, q[contr.qDOF], u[contr.uDOF])
         return coo.asformat(format)
 
     ############
@@ -437,18 +442,20 @@ class System:
             )
         return c
 
-    def c_q(self, t, q, u, la_c, format="coo"):
-        coo = CooMatrix((self.nla_c, self.nq))
-        for contr in self.__c_q_contr:
-            coo[contr.la_cDOF, contr.qDOF] = contr.c_q(
+    def c_q(self, t, q, u, la_c, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nla_c, self.nq))
+        for i, contr in enumerate(self.__c_q_contr):
+            coo[i, contr.la_cDOF, contr.qDOF] = contr.c_q(
                 t, q[contr.qDOF], u[contr.uDOF], la_c[contr.la_cDOF]
             )
         return coo.asformat(format)
 
-    def c_u(self, t, q, u, la_c, format="coo"):
-        coo = CooMatrix((self.nla_c, self.nu))
-        for contr in self.__c_u_contr:
-            coo[contr.la_cDOF, contr.uDOF] = contr.c_u(
+    def c_u(self, t, q, u, la_c, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nla_c, self.nu))
+        for i, contr in enumerate(self.__c_u_contr):
+            coo[i, contr.la_cDOF, contr.uDOF] = contr.c_u(
                 t, q[contr.qDOF], u[contr.uDOF], la_c[contr.la_cDOF]
             )
         return coo.asformat(format)
@@ -456,16 +463,18 @@ class System:
     def c_la_c(self, format="coo"):
         return self._c_la_c0.asformat(format)
 
-    def W_c(self, t, q, format="coo"):
-        coo = CooMatrix((self.nu, self.nla_c))
-        for contr in self.__c_contr:
-            coo[contr.uDOF, contr.la_cDOF] = contr.W_c(t, q[contr.qDOF])
+    def W_c(self, t, q, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nu, self.nla_c))
+        for i, contr in enumerate(self.__c_contr):
+            coo[i, contr.uDOF, contr.la_cDOF] = contr.W_c(t, q[contr.qDOF])
         return coo.asformat(format)
 
-    def Wla_c_q(self, t, q, la_c, format="coo"):
-        coo = CooMatrix((self.nu, self.nq))
-        for contr in self.__c_q_contr:
-            coo[contr.uDOF, contr.qDOF] = contr.Wla_c_q(
+    def Wla_c_q(self, t, q, la_c, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nu, self.nq))
+        for i, contr in enumerate(self.__c_q_contr):
+            coo[i, contr.uDOF, contr.qDOF] = contr.Wla_c_q(
                 t, q[contr.qDOF], la_c[contr.la_cDOF]
             )
         return coo.asformat(format)
@@ -473,10 +482,11 @@ class System:
     ###########
     # actuators
     ###########
-    def W_tau(self, t, q, format="coo"):
-        coo = CooMatrix((self.nu, self.nla_tau))
-        for contr in self.__la_tau_contr:
-            coo[contr.uDOF, contr.la_tauDOF] = contr.W_tau(t, q[contr.qDOF])
+    def W_tau(self, t, q, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nu, self.nla_tau))
+        for i, contr in enumerate(self.__la_tau_contr):
+            coo[i, contr.uDOF, contr.la_tauDOF] = contr.W_tau(t, q[contr.qDOF])
         return coo.asformat(format)
 
     def la_tau(self, t, q, u):
@@ -485,18 +495,20 @@ class System:
             la_tau[contr.la_tauDOF] = contr.la_tau(t, q[contr.qDOF], u[contr.uDOF])
         return la_tau
 
-    def Wla_tau_q(self, t, q, u, format="coo"):
-        coo = CooMatrix((self.nu, self.nq))
-        for contr in self.__la_tau_contr:
-            coo[contr.uDOF, contr.qDOF] = contr.Wla_tau_q(
+    def Wla_tau_q(self, t, q, u, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nu, self.nq))
+        for i, contr in enumerate(self.__la_tau_contr):
+            coo[i, contr.uDOF, contr.qDOF] = contr.Wla_tau_q(
                 t, q[contr.qDOF], u[contr.uDOF]
             )
         return coo.asformat(format)
 
-    def Wla_tau_u(self, t, q, u, format="coo"):
-        coo = CooMatrix((self.nu, self.nu))
-        for contr in self.__la_tau_contr:
-            coo[contr.uDOF, contr.uDOF] = contr.Wla_tau_u(
+    def Wla_tau_u(self, t, q, u, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nu, self.nu))
+        for i, contr in enumerate(self.__la_tau_contr):
+            coo[i, contr.uDOF, contr.uDOF] = contr.Wla_tau_u(
                 t, q[contr.qDOF], u[contr.uDOF]
             )
         return coo.asformat(format)
@@ -534,30 +546,34 @@ class System:
             g[contr.la_gDOF] = contr.g(t, q[contr.qDOF])
         return g
 
-    def g_q(self, t, q, format="coo"):
-        coo = CooMatrix((self.nla_g, self.nq))
-        for contr in self.__g_contr:
-            coo[contr.la_gDOF, contr.qDOF] = contr.g_q(t, q[contr.qDOF])
+    def g_q(self, t, q, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nla_g, self.nq))
+        for i, contr in enumerate(self.__g_contr):
+            coo[i, contr.la_gDOF, contr.qDOF] = contr.g_q(t, q[contr.qDOF])
         return coo.asformat(format)
 
-    def g_q_T_mu_q(self, t, q, mu_g, format="coo"):
-        coo = CooMatrix((self.nq, self.nq))
-        for contr in self.__g_contr:
-            coo[contr.qDOF, contr.qDOF] = contr.g_q_T_mu_q(
+    def g_q_T_mu_q(self, t, q, mu_g, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nq, self.nq))
+        for i, contr in enumerate(self.__g_contr):
+            coo[i, contr.qDOF, contr.qDOF] = contr.g_q_T_mu_q(
                 t, q[contr.qDOF], mu_g[contr.la_gDOF]
             )
         return coo.asformat(format)
 
-    def W_g(self, t, q, format="coo"):
-        coo = CooMatrix((self.nu, self.nla_g))
-        for contr in self.__g_contr:
-            coo[contr.uDOF, contr.la_gDOF] = contr.W_g(t, q[contr.qDOF])
+    def W_g(self, t, q, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nu, self.nla_g))
+        for i, contr in enumerate(self.__g_contr):
+            coo[i, contr.uDOF, contr.la_gDOF] = contr.W_g(t, q[contr.qDOF])
         return coo.asformat(format)
 
-    def Wla_g_q(self, t, q, la_g, format="coo"):
-        coo = CooMatrix((self.nu, self.nq))
-        for contr in self.__g_contr:
-            coo[contr.uDOF, contr.qDOF] = contr.Wla_g_q(
+    def Wla_g_q(self, t, q, la_g, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nu, self.nq))
+        for i, contr in enumerate(self.__g_contr):
+            coo[i, contr.uDOF, contr.qDOF] = contr.Wla_g_q(
                 t, q[contr.qDOF], la_g[contr.la_gDOF]
             )
         return coo.asformat(format)
@@ -572,16 +588,18 @@ class System:
     def chi_g(self, t, q):
         return self.g_dot(t, q, np.zeros(self.nu))
 
-    def g_dot_u(self, t, q, format="coo"):
-        coo = CooMatrix((self.nla_g, self.nu))
-        for contr in self.__g_contr:
-            coo[contr.la_gDOF, contr.uDOF] = contr.g_dot_u(t, q[contr.qDOF])
+    def g_dot_u(self, t, q, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nla_g, self.nu))
+        for i, contr in enumerate(self.__g_contr):
+            coo[i, contr.la_gDOF, contr.uDOF] = contr.g_dot_u(t, q[contr.qDOF])
         return coo.asformat(format)
 
-    def g_dot_q(self, t, q, u, format="coo"):
-        coo = CooMatrix((self.nla_g, self.nq))
-        for contr in self.__g_contr:
-            coo[contr.la_gDOF, contr.qDOF] = contr.g_dot_q(
+    def g_dot_q(self, t, q, u, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nla_g, self.nq))
+        for i, contr in enumerate(self.__g_contr):
+            coo[i, contr.la_gDOF, contr.qDOF] = contr.g_dot_q(
                 t, q[contr.qDOF], u[contr.uDOF]
             )
         return coo.asformat(format)
@@ -611,18 +629,20 @@ class System:
     def chi_gamma(self, t, q):
         return self.gamma(t, q, np.zeros(self.nu))
 
-    def gamma_q(self, t, q, u, format="coo"):
-        coo = CooMatrix((self.nla_gamma, self.nq))
-        for contr in self.__gamma_contr:
-            coo[contr.la_gammaDOF, contr.qDOF] = contr.gamma_q(
+    def gamma_q(self, t, q, u, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nla_gamma, self.nq))
+        for i, contr in enumerate(self.__gamma_contr):
+            coo[i, contr.la_gammaDOF, contr.qDOF] = contr.gamma_q(
                 t, q[contr.qDOF], u[contr.uDOF]
             )
         return coo.asformat(format)
 
-    def gamma_u(self, t, q, format="coo"):
-        coo = CooMatrix((self.nla_gamma, self.nu))
-        for contr in self.__gamma_contr:
-            coo[contr.la_gammaDOF, contr.uDOF] = contr.gamma_u(t, q[contr.qDOF])
+    def gamma_u(self, t, q, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nla_gamma, self.nu))
+        for i, contr in enumerate(self.__gamma_contr):
+            coo[i, contr.la_gammaDOF, contr.uDOF] = contr.gamma_u(t, q[contr.qDOF])
         return coo.asformat(format)
 
     def gamma_dot(self, t, q, u, u_dot):
@@ -633,18 +653,20 @@ class System:
             )
         return gamma_dot
 
-    def gamma_dot_q(self, t, q, u, u_dot, format="coo"):
-        coo = CooMatrix((self.nla_gamma, self.nq))
-        for contr in self.__gamma_contr:
-            coo[contr.la_gammaDOF, contr.qDOF] = contr.gamma_dot_q(
+    def gamma_dot_q(self, t, q, u, u_dot, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nla_gamma, self.nq))
+        for i, contr in enumerate(self.__gamma_contr):
+            coo[i, contr.la_gammaDOF, contr.qDOF] = contr.gamma_dot_q(
                 t, q[contr.qDOF], u[contr.uDOF], u_dot[contr.uDOF]
             )
         return coo.asformat(format)
 
-    def gamma_dot_u(self, t, q, u, u_dot, format="coo"):
-        coo = CooMatrix((self.nla_gamma, self.nu))
-        for contr in self.__gamma_contr:
-            coo[contr.la_gammaDOF, contr.uDOF] = contr.gamma_dot_u(
+    def gamma_dot_u(self, t, q, u, u_dot, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nla_gamma, self.nu))
+        for i, contr in enumerate(self.__gamma_contr):
+            coo[i, contr.la_gammaDOF, contr.uDOF] = contr.gamma_dot_u(
                 t, q[contr.qDOF], u[contr.uDOF], u_dot[contr.uDOF]
             )
         return coo.asformat(format)
@@ -653,16 +675,18 @@ class System:
     def zeta_gamma(self, t, q, u):
         return self.gamma_dot(t, q, u, np.zeros(self.nu))
 
-    def W_gamma(self, t, q, format="coo"):
-        coo = CooMatrix((self.nu, self.nla_gamma))
-        for contr in self.__gamma_contr:
-            coo[contr.uDOF, contr.la_gammaDOF] = contr.W_gamma(t, q[contr.qDOF])
+    def W_gamma(self, t, q, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nu, self.nla_gamma))
+        for i, contr in enumerate(self.__gamma_contr):
+            coo[i, contr.uDOF, contr.la_gammaDOF] = contr.W_gamma(t, q[contr.qDOF])
         return coo.asformat(format)
 
-    def Wla_gamma_q(self, t, q, la_gamma, format="coo"):
-        coo = CooMatrix((self.nu, self.nq))
-        for contr in self.__gamma_contr:
-            coo[contr.uDOF, contr.qDOF] = contr.Wla_gamma_q(
+    def Wla_gamma_q(self, t, q, la_gamma, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nu, self.nq))
+        for i, contr in enumerate(self.__gamma_contr):
+            coo[i, contr.uDOF, contr.qDOF] = contr.Wla_gamma_q(
                 t, q[contr.qDOF], la_gamma[contr.la_gammaDOF]
             )
         return coo.asformat(format)
@@ -676,10 +700,11 @@ class System:
             g_S[contr.la_SDOF] = contr.g_S(t, q[contr.qDOF])
         return g_S
 
-    def g_S_q(self, t, q, format="coo"):
-        coo = CooMatrix((self.nla_S, self.nq))
-        for contr in self.__g_S_contr:
-            coo[contr.la_SDOF, contr.qDOF] = contr.g_S_q(t, q[contr.qDOF])
+    def g_S_q(self, t, q, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nla_S, self.nq))
+        for i, contr in enumerate(self.__g_S_contr):
+            coo[i, contr.la_SDOF, contr.qDOF] = contr.g_S_q(t, q[contr.qDOF])
         return coo.asformat(format)
 
     #################
@@ -691,16 +716,18 @@ class System:
             g_N[contr.la_NDOF] = contr.g_N(t, q[contr.qDOF])
         return g_N
 
-    def g_N_q(self, t, q, format="coo"):
-        coo = CooMatrix((self.nla_N, self.nq))
-        for contr in self.__g_N_contr:
-            coo[contr.la_NDOF, contr.qDOF] = contr.g_N_q(t, q[contr.qDOF])
+    def g_N_q(self, t, q, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nla_N, self.nq))
+        for i, contr in enumerate(self.__g_N_contr):
+            coo[i, contr.la_NDOF, contr.qDOF] = contr.g_N_q(t, q[contr.qDOF])
         return coo.asformat(format)
 
-    def W_N(self, t, q, format="coo"):
-        coo = CooMatrix((self.nu, self.nla_N))
-        for contr in self.__g_N_contr:
-            coo[contr.uDOF, contr.la_NDOF] = contr.W_N(t, q[contr.qDOF])
+    def W_N(self, t, q, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nu, self.nla_N))
+        for i, contr in enumerate(self.__g_N_contr):
+            coo[i, contr.uDOF, contr.la_NDOF] = contr.W_N(t, q[contr.qDOF])
         return coo.asformat(format)
 
     def g_N_dot(self, t, q, u):
@@ -725,10 +752,11 @@ class System:
             ) + contr.e_N * contr.g_N_dot(t_pre, q_pre[contr.qDOF], u_pre[contr.uDOF])
         return xi_N
 
-    def xi_N_q(self, t_post, q_post, u_post, format="coo"):
-        coo = CooMatrix((self.nla_N, self.nq))
-        for contr in self.__g_N_contr:
-            coo[contr.la_NDOF, contr.qDOF] = contr.g_N_dot_q(
+    def xi_N_q(self, t_post, q_post, u_post, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nla_N, self.nq))
+        for i, contr in enumerate(self.__g_N_contr):
+            coo[i, contr.la_NDOF, contr.qDOF] = contr.g_N_dot_q(
                 t_post, q_post[contr.qDOF], u_post[contr.uDOF]
             )
         return coo.asformat(format)
@@ -737,19 +765,21 @@ class System:
     def chi_N(self, t, q):
         return self.g_N_dot(t, q, np.zeros(self.nu), dtype=q.dtype)
 
-    def g_N_dot_u(self, t, q, format="coo"):
+    def g_N_dot_u(self, t, q, format="coo", coo=None):
         warnings.warn(
             "We assume g_N_dot_u(t, q) == W_N(t, q).T. This function will be deleted soon!"
         )
-        coo = CooMatrix((self.nla_N, self.nu))
-        for contr in self.__g_N_contr:
-            coo[contr.la_NDOF, contr.uDOF] = contr.g_N_dot_u(t, q[contr.qDOF])
+        if coo is None:
+            coo = CooMatrix((self.nla_N, self.nu))
+        for i, contr in enumerate(self.__g_N_contr):
+            coo[i, contr.la_NDOF, contr.uDOF] = contr.g_N_dot_u(t, q[contr.qDOF])
         return coo.asformat(format)
 
-    def Wla_N_q(self, t, q, la_N, format="coo"):
-        coo = CooMatrix((self.nu, self.nq))
-        for contr in self.__g_N_contr:
-            coo[contr.uDOF, contr.qDOF] = contr.Wla_N_q(
+    def Wla_N_q(self, t, q, la_N, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nu, self.nq))
+        for i, contr in enumerate(self.__g_N_contr):
+            coo[i, contr.uDOF, contr.qDOF] = contr.Wla_N_q(
                 t, q[contr.qDOF], la_N[contr.la_NDOF]
             )
         return coo.asformat(format)
@@ -779,57 +809,64 @@ class System:
             ) + contr.e_F * contr.gamma_F(t_pre, q_pre[contr.qDOF], u_pre[contr.uDOF])
         return xi_F
 
-    def xi_F_q(self, t_post, q_post, u_post, format="coo"):
-        coo = CooMatrix((self.nla_F, self.nq))
-        for contr in self.__gamma_F_contr:
-            coo[contr.la_FDOF, contr.qDOF] = contr.gamma_F_q(
+    def xi_F_q(self, t_post, q_post, u_post, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nla_F, self.nq))
+        for i, contr in enumerate(self.__gamma_F_contr):
+            coo[i, contr.la_FDOF, contr.qDOF] = contr.gamma_F_q(
                 t_post, q_post[contr.qDOF], u_post[contr.uDOF]
             )
         return coo.asformat(format)
 
-    def gamma_F_q(self, t, q, u, format="coo"):
-        coo = CooMatrix((self.nla_F, self.nq))
-        for contr in self.__gamma_F_q_contr:
-            coo[contr.la_FDOF, contr.qDOF] = contr.gamma_F_q(
+    def gamma_F_q(self, t, q, u, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nla_F, self.nq))
+        for i, contr in enumerate(self.__gamma_F_q_contr):
+            coo[i, contr.la_FDOF, contr.qDOF] = contr.gamma_F_q(
                 t, q[contr.qDOF], u[contr.uDOF]
             )
         return coo.asformat(format)
 
-    def gamma_F_u(self, t, q, format="coo"):
+    def gamma_F_u(self, t, q, format="coo", coo=None):
         warnings.warn(
             "We assume gamma_F_u(t, q) == W_F(t, q).T. This function will be deleted soon!"
         )
-        coo = CooMatrix((self.nla_F, self.nu))
-        for contr in self.__gamma_F_contr:
-            coo[contr.la_FDOF, contr.uDOF] = contr.gamma_F_u(t, q[contr.qDOF])
+        if coo is None:
+            coo = CooMatrix((self.nla_F, self.nu))
+        for i, contr in enumerate(self.__gamma_F_contr):
+            coo[i, contr.la_FDOF, contr.uDOF] = contr.gamma_F_u(t, q[contr.qDOF])
         return coo.asformat(format)
 
-    def gamma_F_dot_q(self, t, q, u, u_dot, format="coo"):
-        coo = CooMatrix((self.nla_F, self.nq))
-        for contr in self.__gamma_F_contr:
-            coo[contr.la_FDOF, contr.qDOF] = contr.gamma_F_dot_q(
+    def gamma_F_dot_q(self, t, q, u, u_dot, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nla_F, self.nq))
+        for i, contr in enumerate(self.__gamma_F_contr):
+            coo[i, contr.la_FDOF, contr.qDOF] = contr.gamma_F_dot_q(
                 t, q[contr.qDOF], u[contr.uDOF], u_dot[contr.uDOF]
             )
         return coo.asformat(format)
 
-    def gamma_F_dot_u(self, t, q, u, u_dot, format="coo"):
-        coo = CooMatrix((self.nla_F, self.nu))
-        for contr in self.__gamma_F_contr:
-            coo[contr.la_FDOF, contr.uDOF] = contr.gamma_F_dot_u(
+    def gamma_F_dot_u(self, t, q, u, u_dot, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nla_F, self.nu))
+        for i, contr in enumerate(self.__gamma_F_contr):
+            coo[i, contr.la_FDOF, contr.uDOF] = contr.gamma_F_dot_u(
                 t, q[contr.qDOF], u[contr.uDOF], u_dot[contr.uDOF]
             )
         return coo.asformat(format)
 
-    def W_F(self, t, q, format="coo"):
-        coo = CooMatrix((self.nu, self.nla_F))
-        for contr in self.__gamma_F_contr:
-            coo[contr.uDOF, contr.la_FDOF] = contr.W_F(t, q[contr.qDOF])
+    def W_F(self, t, q, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nu, self.nla_F))
+        for i, contr in enumerate(self.__gamma_F_contr):
+            coo[i, contr.uDOF, contr.la_FDOF] = contr.W_F(t, q[contr.qDOF])
         return coo.asformat(format)
 
-    def Wla_F_q(self, t, q, la_F, format="coo"):
-        coo = CooMatrix((self.nu, self.nq))
-        for contr in self.__gamma_F_contr:
-            coo[contr.uDOF, contr.qDOF] = contr.Wla_F_q(
+    def Wla_F_q(self, t, q, la_F, format="coo", coo=None):
+        if coo is None:
+            coo = CooMatrix((self.nu, self.nq))
+        for i, contr in enumerate(self.__gamma_F_contr):
+            coo[i, contr.uDOF, contr.qDOF] = contr.Wla_F_q(
                 t, q[contr.qDOF], la_F[contr.la_FDOF]
             )
         return coo.asformat(format)

--- a/cardillo/system.py
+++ b/cardillo/system.py
@@ -313,7 +313,7 @@ class System:
             for contr in self.__M_contr[I_constant_mass_matrix]:
                 coo[contr.uDOF, contr.uDOF] = contr.M(self.t0, self.q0[contr.qDOF])
 
-        self._M0 = coo.tocoo()
+        self._M0 = coo
 
         # - compliance matrix
         coo = CooMatrix((self.nla_c, self.nla_c))
@@ -389,12 +389,16 @@ class System:
     #####################
     # equations of motion
     #####################
-    def M(self, t, q, format="coo"):
+    def M(self, t, q, format="coo", coo=None):
         if np.any(self.I_M):
-            coo = CooMatrix((self.nu, self.nu))
-            for contr in self.__M_contr[self.I_M]:  # only loop over variable mass parts
-                coo[contr.uDOF, contr.uDOF] = contr.M(t, q[contr.qDOF])
-            return coo.asformat(format) + self._M0.asformat(format)
+            if coo is None:
+                coo = CooMatrix((self.nu, self.nu))
+                coo[:, :] = self._M0
+            for i, contr in enumerate(
+                self.__M_contr[self.I_M]
+            ):  # only loop over variable mass parts
+                coo[i, contr.uDOF, contr.uDOF] = contr.M(t, q[contr.qDOF])
+            return coo.asformat(format)
         else:
             return self._M0.asformat(format)
 

--- a/cardillo/utility/coo_matrix.py
+++ b/cardillo/utility/coo_matrix.py
@@ -2,7 +2,8 @@ import warnings
 from scipy.sparse import csc_array, csr_array, coo_array
 from scipy.sparse._sputils import isshape, check_shape
 from scipy.sparse import spmatrix, sparray
-from numpy import repeat, tile, atleast_1d, atleast_2d, arange
+import numpy as np
+from numpy import repeat, tile, atleast_1d, atleast_2d, arange, ndarray
 from array import array
 
 
@@ -44,82 +45,122 @@ class CooMatrix:
 
         # python array as efficient container for numerical data,
         # see https://docs.python.org/3/library/array.html
-        self.__data = array("d", [])  # double
-        self.__row = array("I", [])  # unsigned int
-        self.__col = array("I", [])  # unsigned int
+        self.data = np.empty(0, dtype=float)  # double
+        self.row = np.empty(0, dtype=int)  # unsigned int
+        self.col = np.empty(0, dtype=int)  # unsigned int
+
+        self._data_index = {}
+        self._value_type = {}
+        self._scipy_coo = None
 
     @property
-    def data(self):
-        return self.__data
+    def not_empty(self):
+        return self.data.shape[0] > 0
 
-    @data.setter
-    def data(self, value):
-        self.__data = value
-
-    @property
-    def row(self):
-        return self.__row
-
-    @row.setter
-    def row(self, value):
-        self.__row = value
-
-    @property
-    def col(self):
-        return self.__col
-
-    @col.setter
-    def col(self, value):
-        self.__col = value
+    def set_all(self, rows_list, cols_list, value_list):
+        if len(self.data):
+            self.data = value_list.ravel()
+        else:
+            for rows, cols, value in zip(rows_list, cols_list, value_list):
+                self[rows, cols] = value
 
     def __setitem__(self, key, value):
         # None is returned by every function that does not return. Hence, we
         # can use this to add no contribution to the matrix.
         if value is not None:
-            # extract rows and columns to assign
-            rows, cols = key
-            if isinstance(rows, slice):
-                rows = arange(*rows.indices(self.shape[0]))
-            if isinstance(cols, slice):
-                cols = arange(*cols.indices(self.shape[1]))
-            rows = atleast_1d(rows)
-            cols = atleast_1d(cols)
+            if len(key) == 3:
+                # extract rows and columns to assign
+                name, rows, cols = key
+                pre_allocate = name in self._data_index.keys()
+            elif len(key) == 2:
+                # extract rows and columns to assign
+                rows, cols = key
+                pre_allocate = False
+            else:
+                raise NotImplementedError
 
-            if isinstance(value, CooMatrix):
-                assert value.shape == (len(rows), len(cols)), "inconsistent assignment"
+            if pre_allocate:
+                value_type = self._value_type[name]
+            else:
+                if isinstance(rows, slice):
+                    rows = arange(*rows.indices(self.shape[0]))
+                if isinstance(cols, slice):
+                    cols = arange(*cols.indices(self.shape[1]))
+                rows = atleast_1d(rows)
+                cols = atleast_1d(cols)
+
+                if isinstance(value, CooMatrix):
+                    value_type = "Coo"
+                elif isinstance(value, sparray):
+                    value_type = "sparse"
+                elif isinstance(value, spmatrix):
+                    raise RuntimeError(
+                        "Do not use sparse matrices, move to sparse array."
+                    )
+                elif isinstance(value, ndarray):
+                    value_type = "ndarray"
+                elif isinstance(value, (int, float)):
+                    value_type = "digit"                 
+                else:
+                    raise NotImplementedError
+                if len(key) == 3:
+                    self._value_type[name] = value_type
+
+            if value_type == "Coo":
+                # assert value.shape == (len(rows), len(cols)), "inconsistent assignment"
 
                 # extend arrays from given CooMatrix
-                self.data.extend(value.data)
-                self.row.extend(rows[value.row])
-                self.col.extend(cols[value.col])
+                new_data = value.data
+                if not pre_allocate:
+                    new_rows = rows[value.row]
+                    new_cols = cols[value.col]
                 # TODO: benchmark
                 # self.data.fromlist(value.data.tolist())
                 # self.row.fromlist(rows[value.row].tolist())
                 # self.col.fromlist(cols[value.col].tolist())
-            elif isinstance(value, sparray):
-                assert value.shape == (len(rows), len(cols)), "inconsistent assignment"
+            elif value_type == "sparse":
+                # assert value.shape == (len(rows), len(cols)), "inconsistent assignment"
 
                 # all scipy sparse matrices are converted to coo_array, their
                 # data, row and column lists are subsequently appended
                 coo = value.tocoo()
-                self.data.extend(coo.data)
-                self.row.extend(rows[coo.row])
-                self.col.extend(cols[coo.col])
+                new_data = coo.data
+                if not pre_allocate:
+                    new_rows = rows[coo.row]
+                    new_cols = cols[coo.col]
                 # TODO: benchmark
                 # self.data.fromlist(coo.data.tolist())
                 # self.row.fromlist(rows[coo.row].tolist())
                 # self.col.fromlist(cols[coo.col].tolist())
-            elif isinstance(value, spmatrix):
-                raise RuntimeError("Do not use sparse matrices, move to sparse array.")
-            else:
-                # convert everything als to 2D numpy arrays
-                value = atleast_2d(value)
-                assert value.shape == (len(rows), len(cols)), "inconsistent assignment"
+            elif value_type == "ndarray":
+                # convert to 2D numpy arrays
+                # value = atleast_2d(value)
+                # assert value.shape == (len(rows), len(cols)), "inconsistent assignment"
 
                 # 2D array
-                self.data.extend(value.ravel(order="C"))
-                self.row.extend(repeat(rows, len(cols)))
-                self.col.extend(tile(cols, len(rows)))
+                new_data = value.ravel(order="C")
+                if not pre_allocate:
+                    new_rows = rows.repeat(len(cols))
+                    new_cols = tile(cols, len(rows))
+            elif value_type == "digit":
+                new_rows = rows
+                new_cols = cols
+                new_data = np.array([value])
+            else:
+                raise NotImplementedError
+
+            if pre_allocate:
+                id0, id1 = self._data_index[name]
+                self.data[id0:id1] = new_data
+            else:
+                self.data = np.concatenate([self.data, new_data])
+                self.col = np.concatenate([self.col, new_cols])
+                self.row = np.concatenate([self.row, new_rows])
+                if len(key) == 3:
+                    self._data_index[name] = (
+                        len(self.data) - len(new_data),
+                        len(self.data),
+                    )
 
     def extend(self, matrix, DOF):
         warnings.warn(
@@ -142,6 +183,8 @@ class CooMatrix:
         -------
         A : This matrix in the passed format.
         """
+        if format == "Coo":
+            return self
         try:
             convert_method = getattr(self, "to" + format)
         except AttributeError as e:
@@ -167,7 +210,14 @@ class CooMatrix:
 
     def tocoo(self, copy=False):
         """Convert container to scipy coo_array."""
-        return self.tosparse(coo_array, copy=copy)
+        if copy:
+            coo = self.tosparse(coo_array, copy=True)
+        elif self._scipy_coo is None:
+            coo = self.tosparse(coo_array, copy=False)
+            self._scipy_coo = coo
+        else:
+            coo = self._scipy_coo
+        return coo
 
     def tocsc(self, copy=False):
         """Convert container to scipy csc_array."""
@@ -180,6 +230,29 @@ class CooMatrix:
     def toarray(self, copy=False):
         """Convert container to 2D numpy array."""
         return self.tocoo(copy).toarray()
+
+    def transpose(self, copy=False):
+        ret = CooMatrix((self.shape[1], self.shape[0]))
+        if copy:
+            ret.row = self.col.copy()
+            ret.col = self.row.copy()
+            ret.data = self.data.copy()
+        else:
+            ret.row = self.col
+            ret.col = self.row
+            ret.data = self.data
+        return ret
+
+    @property
+    def T(self):
+        return self.transpose(copy=False)
+
+    def __neg__(self):
+        ret = CooMatrix(self.shape)
+        ret.row = self.row.copy()
+        ret.col = self.col.copy()
+        ret.data = -self.data
+        return ret
 
 
 if __name__ == "__main__":

--- a/cardillo/utility/coo_matrix.py
+++ b/cardillo/utility/coo_matrix.py
@@ -53,17 +53,6 @@ class CooMatrix:
         self._value_type = {}
         self._scipy_coo = None
 
-    @property
-    def not_empty(self):
-        return self.data.shape[0] > 0
-
-    def set_all(self, rows_list, cols_list, value_list):
-        if len(self.data):
-            self.data = value_list.ravel()
-        else:
-            for rows, cols, value in zip(rows_list, cols_list, value_list):
-                self[rows, cols] = value
-
     def __setitem__(self, key, value):
         # None is returned by every function that does not return. Hence, we
         # can use this to add no contribution to the matrix.
@@ -100,7 +89,7 @@ class CooMatrix:
                 elif isinstance(value, ndarray):
                     value_type = "ndarray"
                 elif isinstance(value, (int, float)):
-                    value_type = "digit"                 
+                    value_type = "digit"
                 else:
                     raise NotImplementedError
                 if len(key) == 3:


### PR DESCRIPTION
The functionality of CooMatrix has been extended to better exploit matrix sparsity. The matrix structure is assembled only once during initialization, and its values are subsequently updated in place (e.g. Jocobians in System and ScipyDAE). This approach improves performance, making the double pendulum example run roughly twice as fast.

@JonasBreuling We should discuss this approach, if it should be implemented for other solvers.